### PR TITLE
Fixed ASF export output format

### DIFF
--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -22,7 +22,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product>> }) {
           !product.is_expired &&
           product.key_type === 'steam'
       )
-      .map((product) => `${product.redeemed_key_val}\t${product.human_name}`)
+      .map((product) => `${product.human_name}\t${product.redeemed_key_val}`)
       .join('\n')
 
     navigator.clipboard.writeText(keys)


### PR DESCRIPTION
ASF expects game name separated by a tab and then the key. The Code was using key, tab, game name. ASF will silently ignore this. Tested it with this configuration and ASF will pick it up and process the keys fine.

Documentation: https://github.com/JustArchiNET/ArchiSteamFarm/wiki/Background-games-redeemer