### PR TITLE
Fix expiration date range filtering in the table

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -10,13 +10,24 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
   let tableRef!: HTMLTableElement
   onMount(() => {
     console.debug('Mounting table with', products.length, 'products')
+
+    // Cast: TypeScript thinks render.date() isn’t callable
+    type DtRender<T> = (data: unknown, type: string, row: T, meta: unknown) => string
+    const dtDate = DataTable.render.date() as unknown as DtRender<Product>
+
     setDt(
       () =>
         new DataTable<Product>(tableRef, {
           columnDefs: [
             {
               targets: [7, 8],
-              render: DataTable.render.date(),
+              render: (data, type, row, meta) => {
+                if (!data) return ''
+
+                if (type === 'display') return dtDate(data, type, row, meta) // Formatted date for display
+
+                return data // Raw ISO date for SearchBuilder filter + correct sorting
+              },
             },
             {
               targets: [9],


### PR DESCRIPTION
## What
Expiration date range filtering in the DataTables SearchBuilder UI didn’t work reliably, even though values were present.

## Why
SearchBuilder uses orthogonal render data. Using `DataTable.render.date()` directly formats values for display, which can break date comparisons.

## Changes
- Custom renderer for `Purchased` and `Exp. Date`:
  - `display`: formatted date (DataTables renderer)
  - non-`display`: raw ISO date (for SearchBuilder filtering and correct sorting)

## Testing
- Confirm SearchBuilder `Exp. Date` filters (equals/before/after/between) work
- Confirm table display remains unchanged

Closes #10