### PR TITLE
fix: correct Steam owned games detection and improve Advanced Exporter UX

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,6 +7,8 @@ import { Actions } from './components/Actions'
 import type { Api } from 'datatables.net-dt'
 
 export function App() {
+  const [open, setOpen] = createSignal(false)
+
   const [products, { refetch: refresh }] = createResource<Product[], boolean>(async (_, info) => {
     console.debug('Loading products...')
     const orders = loadOrders()
@@ -18,20 +20,27 @@ export function App() {
 
   const [dt, setDt] = createSignal<Api<Product> | null>(null)
   console.debug('App loaded')
+
   return (
-    <details>
-      <summary>
-        <h3>
-          <i class="hb hb-key"></i> Advanced Exporter
-        </h3>
-      </summary>
-      <div style={{ display: 'flex', 'justify-content': 'end', 'align-items': 'center' }}>
-        <Refresh refresh={refresh} />
+    <>
+      <button
+        type="button"
+        class="js-big-button js-nav-button"
+        onClick={() => setOpen((v) => !v)}
+        style={{ 'margin-bottom': '10px' }}
+      >
+        <i class="hb hb-key"></i> Advanced Exporter
+      </button>
+
+      <div classList={{ hidden: !open() }}>
+        <div style={{ display: 'flex', 'justify-content': 'end', 'align-items': 'center' }}>
+          <Refresh refresh={refresh} />
+        </div>
+        <Show when={products()?.length} fallback={<p>Loading products...</p>}>
+          <Table products={products()} setDt={setDt} />
+        </Show>
+        <Actions dt={dt} />
       </div>
-      <Show when={products()?.length} fallback={<p>Loading products...</p>}>
-        <Table products={products()} setDt={setDt} />
-      </Show>
-      <Actions dt={dt} />
-    </details>
+    </>
   )
 }

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -6,8 +6,8 @@ import styles from '../style.module.css'
 import type { Api } from 'datatables.net-dt'
 
 export function Actions({ dt }: { dt: Accessor<Api<Product>> }) {
-  const [exportType, setExportType] = createSignal('')
-  const [filtered, setFiltered] = createSignal(false)
+  const [exportType, setExportType] = createSignal('csv')
+  const [filtered, setFiltered] = createSignal(true)
   const [claim, setClaim] = createSignal(false)
   const [claimType, setClaimType] = createSignal('key')
   const [exporting, setExporting] = createSignal(false)
@@ -125,6 +125,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product>> }) {
             type="checkbox"
             id="claim"
             name="claim"
+            checked={claim()}
             onChange={(e) => setClaim(e.target.checked)}
           />
           Claim unredeemed games
@@ -149,6 +150,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product>> }) {
             type="checkbox"
             id="filtered"
             name="filtered"
+            checked={filtered()}
             onChange={(e) => setFiltered(e.target.checked)}
           />
           Use table filter
@@ -157,11 +159,9 @@ export function Actions({ dt }: { dt: Accessor<Api<Product>> }) {
           name="export"
           id="export"
           class={styles.select}
+          value={exportType()}
           onChange={(e) => setExportType(e.target.value)}
         >
-          <option value="" disabled selected>
-            Export format
-          </option>
           <option value="asf">ASF</option>
           <option value="keys">Keys</option>
           <option value="csv">CSV</option>

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,4 +1,4 @@
-import { onMount, type Setter } from 'solid-js'
+import { onCleanup, onMount, type Setter } from 'solid-js'
 import { redeem, type Product } from '../util'
 import DataTable, { type Api } from 'datatables.net-dt'
 import { hm } from '@violentmonkey/dom'
@@ -8,26 +8,39 @@ import { showToast } from '@violentmonkey/ui'
 
 export function Table({ products, setDt }: { products: Product[]; setDt: Setter<Api<Product>> }) {
   let tableRef!: HTMLTableElement
+
   onMount(() => {
     console.debug('Mounting table with', products.length, 'products')
 
-    // Cast: TypeScript thinks render.date() isn’t callable
+    // Cast: TypeScript thinks render.date() isn't callable
     type DtRender<T> = (data: unknown, type: string, row: T, meta: unknown) => string
     const dtDate = DataTable.render.date() as unknown as DtRender<Product>
 
+    const renderCellValue = (data: unknown, type: string): string | undefined => {
+      if (data == null || data === '') return type === 'display' ? '-' : ''
+      if (type !== 'display') return String(data)
+      return undefined
+    }
+
+    const displayDash = (data: unknown, type: string): string =>
+      !data ? (type === 'display' ? '-' : '') : String(data)
+
+    const displayDate = (data: unknown, type: string, row: Product, meta: unknown): string => {
+      if (!data) return type === 'display' ? '-' : ''
+
+      if (type === 'display') return dtDate(data, type, row, meta) // Formatted date for display
+
+      return String(data) // Raw ISO date for SearchBuilder filter + correct sorting
+    }
+
+    let dt!: Api<Product>
     setDt(
       () =>
-        new DataTable<Product>(tableRef, {
+        (dt = new DataTable<Product>(tableRef, {
           columnDefs: [
             {
               targets: [7, 8],
-              render: (data, type, row, meta) => {
-                if (!data) return ''
-
-                if (type === 'display') return dtDate(data, type, row, meta) // Formatted date for display
-
-                return data // Raw ISO date for SearchBuilder filter + correct sorting
-              },
+              render: displayDate,
             },
             {
               targets: [9],
@@ -35,58 +48,77 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
               defaultContent: '',
             },
           ],
-          order: {
-            idx: 7,
-            dir: 'desc',
-          },
+          order: [[7, 'desc']],
           columns: [
             {
               title: 'Type',
               data: 'key_type',
               type: 'html-utf8',
-              render: (data, type, row) =>
-                hm(
+              render: (data, type, row) => {
+                const value = renderCellValue(data, type)
+                if (value !== undefined) return value
+
+                return hm(
                   'i',
                   {
                     class: `hb hb-key hb-${data}`,
                     onclick: () => showToast(JSON.stringify(row, null, 2)),
                   },
-                  hm('span', { class: 'hidden', innerText: data })
-                ),
+                  hm('span', { class: 'hidden', innerText: String(data) })
+                )
+              },
               className: styles.platform,
             },
             {
               title: 'Name',
               data: 'human_name',
               type: 'html-utf8',
-              render: (data, _, row) =>
-                row.steam_app_id
+              render: (data, type, row) => {
+                const value = renderCellValue(data, type)
+                if (value !== undefined) return value
+
+                return row.steam_app_id
                   ? hm('a', {
                       href: `https://store.steampowered.com/app/${row.steam_app_id}`,
                       target: '_blank',
-                      innerText: data,
+                      innerText: String(data),
                     })
-                  : data,
+                  : String(data)
+              },
             },
             { title: 'Category', data: 'category', type: 'string-utf8' },
             {
               title: 'Bundle Name',
               data: 'category_human_name',
               type: 'html-utf8',
-              render: (data, _, row) =>
-                hm('a', {
+              render: (data, type, row) => {
+                const value = renderCellValue(data, type)
+                if (value !== undefined) return value
+
+                return hm('a', {
                   href: `https://www.humblebundle.com/download?key=${row.category_id}`,
                   target: '_blank',
-                  innerText: data,
-                }),
+                  innerText: String(data),
+                })
+              },
             },
-            { title: 'Gift', data: 'type', type: 'string-utf8' },
+            {
+              title: 'Gift',
+              data: 'type',
+              type: 'string-utf8',
+              render: displayDash,
+            },
             {
               title: 'Revealed',
               data: (row: Product) => (row.is_gift || row.redeemed_key_val ? 'Yes' : 'No'),
               type: 'string-utf8',
             },
-            { title: 'Owned', data: 'owned', type: 'string-utf8' },
+            {
+              title: 'Owned',
+              data: 'owned',
+              type: 'string-utf8',
+              render: displayDash,
+            },
             { title: 'Purchased', data: 'created', type: 'date' },
             { title: 'Exp. Date', data: 'expiry_date', type: 'date' },
             {
@@ -95,6 +127,7 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
               searchable: false,
               data: (row: Product) => {
                 const actions = []
+
                 if (row.redeemed_key_val) {
                   actions.push(
                     hm(
@@ -112,6 +145,7 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                     )
                   )
                 }
+
                 if (
                   row.redeemed_key_val &&
                   !row.is_gift &&
@@ -152,10 +186,14 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                       {
                         class: styles.btn,
                         type: 'button',
-                        onclick: () => {
-                          redeem(row)
-                            .then((data) => navigator.clipboard.writeText(data))
-                            .then(() => showToast('Key copied to clipboard'))
+                        onclick: async () => {
+                          try {
+                            const key = await redeem(row)
+                            await navigator.clipboard.writeText(key)
+                            showToast('Key copied to clipboard')
+                          } catch (error) {
+                            showToast(error instanceof Error ? error.message : String(error))
+                          }
                         },
                       },
                       hm('i', { class: 'hb hb-magic', title: 'Reveal' })
@@ -165,10 +203,14 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                       {
                         class: styles.btn,
                         type: 'button',
-                        onclick: () => {
-                          redeem(row, true)
-                            .then((link) => navigator.clipboard.writeText(link))
-                            .then(() => showToast('Link copied to clipboard'))
+                        onclick: async () => {
+                          try {
+                            const link = await redeem(row, true)
+                            await navigator.clipboard.writeText(link)
+                            showToast('Link copied to clipboard')
+                          } catch (error) {
+                            showToast(error instanceof Error ? error.message : String(error))
+                          }
                         },
                       },
                       hm('i', { class: 'hb hb-gift', title: 'Create gift link' })
@@ -182,15 +224,81 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
           ],
           data: products,
           layout: {
-            top1: 'searchBuilder',
+            top1: {
+              searchBuilder: {
+                columns: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+              },
+            },
           },
           createdRow: function (row, data: Product) {
             if (data.is_expired) {
               row.classList.add(styles.expired)
             }
           },
-        })
+        }))
     )
+
+    // Warnings when selecting certain column filters
+
+    const container = dt.table().container() as HTMLElement
+    const searchBuilderRoot = container.querySelector('.dtsb-searchBuilder') as HTMLElement | null
+
+    type WarningRule = {
+      element: HTMLElement
+      show: (selectedColumns: string[]) => boolean
+    }
+
+    const makeWarning = (text: string): HTMLElement =>
+      hm('div', {
+        class: 'warning-wrapper',
+        innerText: text,
+        hidden: true,
+      }) as HTMLElement
+
+    const getSelectedColumns = (): string[] =>
+      Array.from(
+        searchBuilderRoot?.querySelectorAll<HTMLSelectElement>('select.dtsb-data') ?? []
+      ).map((select) => select.selectedOptions[0]?.text.trim() ?? '')
+
+    const warnings: WarningRule[] = [
+      {
+        element: makeWarning(
+          '⚠️ "Owned" column: Keys containing packages can incorrectly appear owned when only the base game is owned. This column may also contain many null values.'
+        ),
+        show: (selectedColumns) => selectedColumns.includes('Owned'),
+      },
+    ]
+
+    for (const warning of warnings) {
+      container.insertAdjacentElement('beforebegin', warning.element)
+    }
+
+    const refreshWarnings = (): void => {
+      const selectedColumns = getSelectedColumns()
+
+      for (const warning of warnings) {
+        warning.element.hidden = !warning.show(selectedColumns)
+      }
+    }
+
+    refreshWarnings()
+
+    searchBuilderRoot?.addEventListener('change', refreshWarnings)
+
+    const observer = searchBuilderRoot ? new MutationObserver(refreshWarnings) : null
+
+    if (searchBuilderRoot) {
+      observer?.observe(searchBuilderRoot, {
+        subtree: true,
+        childList: true,
+      })
+    }
+
+    onCleanup(() => {
+      searchBuilderRoot?.removeEventListener('change', refreshWarnings)
+      observer?.disconnect()
+      for (const warning of warnings) warning.element.remove()
+    })
   })
   console.debug('Table Loaded')
   return <table ref={tableRef} id="hb_extractor-table" class="display compact"></table>

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,6 +6,15 @@
   width: 1020px !important;
 }
 
+.warning-wrapper {
+  margin: 10px 0;
+  padding: 8px 10px;
+  background: #fff3cd;
+  color: #664d03;
+  border: 1px solid #ffecb5;
+  border-radius: 4px;
+}
+
 #hb_extractor-container {
   margin-bottom: 15px;
 }
@@ -17,4 +26,13 @@
 
 #hb_extractor-container .dtsb-titleRow {
   display: none;
+}
+
+#hb_extractor-container .dt-search input,
+#hb_extractor-container input[type='search'],
+#hb_extractor-container .dtsb-value,
+#hb_extractor-container .dtsb-input,
+#hb_extractor-container .dt-length select {
+  background: #fff !important;
+  color: #000 !important;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -34,11 +34,11 @@ export interface Product {
   category_human_name: string
   human_name: string
   key_type: string
-  type: 'Key' | 'Gift' | '-'
+  type: 'Key' | 'Gift' | ''
   redeemed_key_val: string
   is_gift: boolean
   is_expired: boolean
-  owned: 'Yes' | 'No' | '-'
+  owned: 'Yes' | 'No' | ''
   expiry_date?: string
   steam_app_id?: number
   created: string
@@ -262,13 +262,13 @@ export const getProducts = (orders: Order[], ownedApps: number[]): Product[] =>
       const isExpired = product.is_expired || (!Number.isNaN(expiryMs) && expiryMs < Date.now())
 
       return {
-        machine_name: product.machine_name || '-',
+        machine_name: product.machine_name || '',
         category: getCategory(order.product.category),
         category_id: order.gamekey,
-        category_human_name: order.product.human_name || '-',
-        human_name: product.human_name || product.machine_name || '-',
-        key_type: product.key_type || '-',
-        type: product.is_gift ? 'Gift' : product.redeemed_key_val ? 'Key' : '-',
+        category_human_name: order.product.human_name || '',
+        human_name: product.human_name || product.machine_name || '',
+        key_type: product.key_type || '',
+        type: product.is_gift ? 'Gift' : product.redeemed_key_val ? 'Key' : '',
         redeemed_key_val: product.redeemed_key_val || '',
         is_gift: product.is_gift || false,
         is_expired: isExpired,
@@ -280,16 +280,12 @@ export const getProducts = (orders: Order[], ownedApps: number[]): Product[] =>
           ? ownedApps.includes(product.steam_app_id)
             ? 'Yes'
             : 'No'
-          : '-',
+          : '',
       }
     })
   )
 
-export const redeem = async (
-  product: Pick<Product, 'machine_name' | 'category_id' | 'keyindex'>,
-  gift: boolean = false
-) => {
-  console.log('Redeeming product:', product.machine_name)
+export const redeem = async (product: Product, gift = false): Promise<string> => {
   const data = await fetch('https://www.humblebundle.com/humbler/redeemkey', {
     credentials: 'include',
     headers: {
@@ -299,48 +295,65 @@ export const redeem = async (
     method: 'POST',
     mode: 'cors',
   }).then((res) => res.json())
-  console.log('Redeem response:', data)
 
-  return gift ? `https://www.humblebundle.com/gift?key=${data.giftkey}` : (data.key as string)
+  if (!data?.success) {
+    throw new Error(data?.error_msg || data?.error || 'Failed to reveal key')
+  }
+
+  const value = gift ? data.giftkey : data.key
+  if (!value) throw new Error('Failed to reveal key')
+
+  return gift ? `https://www.humblebundle.com/gift?key=${value}` : value
 }
 
-const fetchOwnedApps = async (): Promise<Array<number>> =>
-  new Promise<VMScriptResponseObject<{ rgOwnedPackages: number[]; rgOwnedApps: number[] }>>(
-    (resolve) =>
-      GM_xmlhttpRequest({
-        url: 'https://store.steampowered.com/dynamicstore/userdata',
-        method: 'GET',
-        timeout: 5000,
-        responseType: 'json',
-        onload: resolve,
-      })
-  )
-    .then((data) =>
-      (data?.response?.rgOwnedPackages || []).concat(data?.response?.rgOwnedApps || [])
-    )
-    .catch(() => [])
+type SteamUserData = {
+  rgOwnedApps?: number[]
+}
 
-let ownedApps: Array<number> = []
-export const loadOwnedApps = async (refresh: boolean = false) => {
+const fetchOwnedApps = async (): Promise<number[]> =>
+  new Promise<VMScriptResponseObject<unknown>>((resolve, reject) =>
+    GM_xmlhttpRequest({
+      url: `https://store.steampowered.com/dynamicstore/userdata?_=${Date.now()}`, // Blank query to force a cache reload every time
+      method: 'GET',
+      timeout: 5000,
+      responseType: 'json',
+      onload: (res) => {
+        if (res.status !== 200) {
+          console.error(`Steam owned apps request failed with HTTP ${res.status}`)
+          reject(new Error(`HTTP ${res.status}`))
+          return
+        }
+
+        resolve(res)
+      },
+      onerror: (err) => {
+        console.error('Steam owned apps request error:', err)
+        reject(new Error('Steam owned apps request failed'))
+      },
+      ontimeout: () => {
+        console.error('Steam owned apps request timed out')
+        reject(new Error('Steam owned apps request timed out'))
+      },
+    })
+  )
+    .then((data) => {
+      const apps = (data.response as SteamUserData | null)?.rgOwnedApps ?? []
+      console.debug(`Steam owned apps fetched: ${apps.length}`)
+      return apps
+    })
+    .catch((err) => {
+      console.error('Failed to load Steam owned apps:', err)
+      return []
+    })
+
+let ownedApps: number[] = []
+
+export const loadOwnedApps = async (refresh: boolean = false): Promise<number[]> => {
   if (!refresh && ownedApps.length) {
-    console.debug('Using cached owned apps')
+    console.debug(`Steam owned apps returned from memory: ${ownedApps.length}`)
     return ownedApps
   }
-  console.debug('Fetching owned apps from Steam')
-  // Try to load from localStorage first
-  const storedApps = localStorage.getItem('hb-key-exporter-ownedApps')
-  if (storedApps) {
-    return JSON.parse(LZString.decompressFromUTF16(storedApps)) as Array<number>
-  }
-  // If not found, fetch from Steam
+
   ownedApps = await fetchOwnedApps()
-  if (!ownedApps) {
-    return []
-  }
-  // Store the result in localStorage for future use
-  localStorage.setItem(
-    'hb-key-exporter-ownedApps',
-    LZString.compressToUTF16(JSON.stringify(ownedApps))
-  )
   return ownedApps
 }


### PR DESCRIPTION
## Summary

Correct Steam owned games detection and improve the Advanced Exporter UX.

## Changes

- Remove stale localStorage-backed Steam ownership caching
- Force fresh Steam userdata requests with a cache-busting query parameter
- Match owned games using app IDs only
- Keep blank values empty internally and render dashes only in the UI
- Add SearchBuilder warnings for unreliable column filters, such as `Owned`
- Exclude the blank actions column from SearchBuilder
- Surface exact Humble API error messages for key reveal and gift link actions
- Default the export format to CSV
- Default "Use table filter" to enabled so exports match the current table view by default
- Make the checkbox controlled so the UI stays in sync with its state
- Restyle Advanced Exporter text as a toggle button
- Improve input background readability in DataTables/SearchBuilder

## Notes

- The `Owned` column can get bad data from the Humble Bundle API, such as incorrect or null app IDs (Humble's schema can be very inconsistent)