### PR TITLE
Fix expiration date and purchase date display and filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hb-key-exporter",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Userscript that aids in exporting Humble Bundle keys from the Humble Bundle website.",
   "type": "module",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hb-key-exporter",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Userscript that aids in exporting Humble Bundle keys from the Humble Bundle website.",
   "type": "module",
   "private": true,

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -35,10 +35,18 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
 
     const displayDateTime = (data: unknown, type: string): string => {
       if (!data) return type === 'display' ? '-' : ''
-      if (type !== 'display') return String(data)
 
       const date = new Date(String(data))
       if (Number.isNaN(date.getTime())) return String(data)
+
+      if (type === 'filter') {
+        const year = date.getFullYear()
+        const month = String(date.getMonth() + 1).padStart(2, '0')
+        const day = String(date.getDate()).padStart(2, '0')
+        return `${year}-${month}-${day}`
+      }
+
+      if (type !== 'display') return String(data)
 
       return `${date.toLocaleDateString()}<br>${date.toLocaleTimeString()}`
     }

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -76,6 +76,14 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
       }
     }
 
+    const afterDateCondition = searchBuilderCriteria?.dateConditions?.['>']
+    if (afterDateCondition) {
+      afterDateCondition.search = (value: string, comparison: string[]) => {
+        value = value.replace(/(\/|-|,)/g, '-')
+        return value.length > 0 && value >= comparison[0]
+      }
+    }
+
     let dt!: Api<Product>
     setDt(
       () =>

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -57,6 +57,25 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
       return `${date.toLocaleDateString()}<br>${time}`
     }
 
+    const searchBuilderCriteria = (
+      DataTable as typeof DataTable & {
+        Criteria?: {
+          dateConditions?: Record<
+            string,
+            { search?: (value: string, comparison: string[]) => boolean }
+          >
+        }
+      }
+    ).Criteria
+
+    const beforeDateCondition = searchBuilderCriteria?.dateConditions?.['<']
+    if (beforeDateCondition) {
+      beforeDateCondition.search = (value: string, comparison: string[]) => {
+        value = value.replace(/(\/|-|,)/g, '-')
+        return value.length > 0 && value < comparison[0]
+      }
+    }
+
     let dt!: Api<Product>
     setDt(
       () =>
@@ -197,7 +216,11 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                 return btn as unknown as string
               },
             },
-            { title: 'Exp. Date', data: 'expiry_date', type: 'date' },
+            {
+              title: 'Exp. Date',
+              data: 'expiry_date',
+              type: 'date',
+            },
             {
               title: '',
               orderable: false,

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -48,7 +48,13 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
 
       if (type !== 'display') return String(data)
 
-      return `${date.toLocaleDateString()}<br>${date.toLocaleTimeString()}`
+      const time = date.toLocaleTimeString(undefined, {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      })
+
+      return `${date.toLocaleDateString()}<br>${time}`
     }
 
     let dt!: Api<Product>

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -33,14 +33,28 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
       return String(data) // Raw ISO date for SearchBuilder filter + correct sorting
     }
 
+    const displayDateTime = (data: unknown, type: string): string => {
+      if (!data) return type === 'display' ? '-' : ''
+      if (type !== 'display') return String(data)
+
+      const date = new Date(String(data))
+      if (Number.isNaN(date.getTime())) return String(data)
+
+      return `${date.toLocaleDateString()}<br>${date.toLocaleTimeString()}`
+    }
+
     let dt!: Api<Product>
     setDt(
       () =>
         (dt = new DataTable<Product>(tableRef, {
           columnDefs: [
             {
-              targets: [7, 9],
+              targets: [7],
               render: displayDate,
+            },
+            {
+              targets: [9],
+              render: displayDateTime,
             },
             {
               targets: [10],

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -12,10 +12,6 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
   onMount(() => {
     console.debug('Mounting table with', products.length, 'products')
 
-    // Cast: TypeScript thinks render.date() isn't callable
-    type DtRender<T> = (data: unknown, type: string, row: T, meta: unknown) => string
-    const dtDate = DataTable.render.date() as unknown as DtRender<Product>
-
     const renderCellValue = (data: unknown, type: string): string | undefined => {
       if (data == null || data === '') return type === 'display' ? '-' : ''
       if (type !== 'display') return String(data)
@@ -24,14 +20,6 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
 
     const displayDash = (data: unknown, type: string): string =>
       !data ? (type === 'display' ? '-' : '') : String(data)
-
-    const displayDate = (data: unknown, type: string, row: Product, meta: unknown): string => {
-      if (!data) return type === 'display' ? '-' : ''
-
-      if (type === 'display') return dtDate(data, type, row, meta) // Formatted date for display
-
-      return String(data) // Raw ISO date for SearchBuilder filter + correct sorting
-    }
 
     const displayDateTime = (data: unknown, type: string): string => {
       if (!data) return type === 'display' ? '-' : ''
@@ -90,11 +78,7 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
         (dt = new DataTable<Product>(tableRef, {
           columnDefs: [
             {
-              targets: [7],
-              render: displayDate,
-            },
-            {
-              targets: [9],
+              targets: [7, 9],
               render: displayDateTime,
             },
             {


### PR DESCRIPTION
## Summary

- Show expiration dates with local date and 24-hour time on separate lines.
- Compare expiration filters by local calendar day so Equals and Between work correctly.
- Exclude empty expiration dates from Before filters.
- Include the selected day in After filters.
- Update the version to 0.5.1.

1. Equals: The entire selected day
1. Between: From the start date at 00:00 to the end date at 24:00
1. After: After the selected date at 00:00
1. Before: Before the selected date at 00:00

<img width="766" height="227" alt="image" src="https://github.com/user-attachments/assets/055013dd-5610-474a-8e15-c1c2b07bd87f" />

<img width="1020" height="363" alt="image" src="https://github.com/user-attachments/assets/7ae4fab8-0311-4dff-9199-d2e134d6e99c" />
<img width="1020" height="429" alt="image" src="https://github.com/user-attachments/assets/c2c423e5-ef3f-4307-9166-c54f9d0c6d10" />
<img width="1020" height="410" alt="image" src="https://github.com/user-attachments/assets/5ec36e80-ee02-49e1-b503-2a6e81d25d01" />
<img width="1020" height="363" alt="image" src="https://github.com/user-attachments/assets/62e3e2ee-aae7-49f9-ba48-fefe3853fc4b" />
