### PR TITLE
Fix date filtering and add local time toggle (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 0.5.1 (2026-06-19)
+
+
+### Bug Fixes
+
+* compare expiration dates by day
+* show expiration time in 24-hour format
+* exclude empty expiration dates from before filter
+* include selected day in expiration after filter
+* align purchase date rendering with expiration date
+
+
+### Features
+
+* add local time date toggle
+
+
 # [0.5.0](https://github.com/MrMarble/hb-key-exporter/compare/v0.4.2...v0.5.0) (2026-05-21)
 
 
@@ -10,6 +27,7 @@
 
 * Add `purchase date` column ([#34](https://github.com/MrMarble/hb-key-exporter/issues/34)) ([dba9f33](https://github.com/MrMarble/hb-key-exporter/commit/dba9f337876ac4fd4f72b4359041e80e211336d6))
 
+
 ## [0.4.2](https://github.com/MrMarble/hb-key-exporter/compare/v0.4.1...v0.4.2) (2026-05-21)
 
 
@@ -20,11 +38,13 @@
 * **table:** make expiration date filtering work with ISO date values ([#14](https://github.com/MrMarble/hb-key-exporter/issues/14)) ([5ac9b81](https://github.com/MrMarble/hb-key-exporter/commit/5ac9b812541b3afc3b33577c1495ceab77a60326))
 
 
-
 # [0.4.1](https://github.com/MrMarble/hb-key-exporter/compare/v0.4.0...v0.4.1) (2026-02-05)
 
+
 ### Bug Fixes
+
 * Fixed ASF export output format by @Knight1 in #6
+
 
 # [0.4.0](https://github.com/MrMarble/hb-key-exporter/compare/v0.3.0...v0.4.0) (2025-05-31)
 
@@ -32,7 +52,6 @@
 ### Features
 
 * **cvs:** allow setting a custom separator ([#2](https://github.com/MrMarble/hb-key-exporter/issues/2)) ([30aaff5](https://github.com/MrMarble/hb-key-exporter/commit/30aaff5848797c15c40e6e55599412c366049324))
-
 
 
 # [0.3.0](https://github.com/MrMarble/hb-key-exporter/compare/v0.2.1...0.3.0) (2025-05-11)
@@ -48,14 +67,12 @@
 * show owned apps ([82ecc2e](https://github.com/MrMarble/hb-key-exporter/commit/82ecc2e35c9394ac4171c704425205cdbc707839))
 
 
-
 ## [0.2.1](https://github.com/MrMarble/hb-key-exporter/compare/v0.2.0...v0.2.1) (2025-05-09)
 
 
 ### Bug Fixes
 
 * add default values ([c1cda4a](https://github.com/MrMarble/hb-key-exporter/commit/c1cda4a00957cc0102129777b9907ad976a0e76f))
-
 
 
 # [0.2.0](https://github.com/MrMarble/hb-key-exporter/compare/v0.1.1...v0.2.0) (2025-05-08)
@@ -73,7 +90,6 @@
 * show unrevealed keys ([fcf44e2](https://github.com/MrMarble/hb-key-exporter/commit/fcf44e27927a7806175862f87b19f2e35ff7ea74))
 
 
-
 ## [0.1.1](https://github.com/MrMarble/hb-key-exporter/compare/v0.1.0...v0.1.1) (2025-05-07)
 
 
@@ -82,8 +98,5 @@
 * add uptate urls to meta ([6068fbf](https://github.com/MrMarble/hb-key-exporter/commit/6068fbfb6911a91b9a2caa41850d26d0b7fad948))
 
 
-
 # 0.1.0 (2025-05-07)
-
-
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Userscript to assist in key management for Humble Bundle games.
 - Reveal hidden keys
 - Create Gift links
 - Show purchase dates for owned Steam games
+- Toggle purchase and expiration dates between UTC and local time
 - Bulk claim keys!
 
 ## Installation
@@ -31,7 +32,7 @@ Userscript to assist in key management for Humble Bundle games.
 
 Go to Humble Bundle [keys page](https://www.humblebundle.com/home/keys), open the collapsible menu by clicking on the `Advanced Exporter` at the top of the main section.
 
->[!NOTE]
+> [!NOTE]
 > You need to be signed in to Steam for some of the features to work, such as showing purchase dates and claiming keys.
 
 ## Troubleshooting

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hb-key-exporter",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Userscript that aids in exporting Humble Bundle keys from the Humble Bundle website.",
   "type": "module",
   "private": true,

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,6 +8,7 @@ import type { Api } from 'datatables.net-dt'
 
 export function App() {
   const [open, setOpen] = createSignal(false)
+  const [useLocalTime, setUseLocalTime] = createSignal(false)
 
   const [products, { refetch: refresh }] = createResource<Product[], boolean>(async (_, info) => {
     console.debug('Loading products...')
@@ -33,11 +34,27 @@ export function App() {
       </button>
 
       <div classList={{ hidden: !open() }}>
-        <div style={{ display: 'flex', 'justify-content': 'end', 'align-items': 'center' }}>
+        <div
+          style={{
+            display: 'flex',
+            'justify-content': 'space-between',
+            'align-items': 'center',
+            'margin-bottom': '10px',
+          }}
+        >
+          <label for="hb_extractor-local-time">
+            <input
+              type="checkbox"
+              id="hb_extractor-local-time"
+              checked={useLocalTime()}
+              onChange={(e) => setUseLocalTime(e.currentTarget.checked)}
+            />
+            Local time
+          </label>
           <Refresh refresh={refresh} />
         </div>
         <Show when={products()?.length} fallback={<p>Loading products...</p>}>
-          <Table products={products()} setDt={setDt} />
+          <Table products={products()} setDt={setDt} useLocalTime={useLocalTime} />
         </Show>
         <Actions dt={dt} />
       </div>

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -35,10 +35,18 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
 
     const displayDateTime = (data: unknown, type: string): string => {
       if (!data) return type === 'display' ? '-' : ''
-      if (type !== 'display') return String(data)
 
       const date = new Date(String(data))
       if (Number.isNaN(date.getTime())) return String(data)
+
+      if (type === 'filter') {
+        const year = date.getFullYear()
+        const month = String(date.getMonth() + 1).padStart(2, '0')
+        const day = String(date.getDate()).padStart(2, '0')
+        return `${year}-${month}-${day}`
+      }
+
+      if (type !== 'display') return String(data)
 
       return `${date.toLocaleDateString()}<br>${date.toLocaleTimeString()}`
     }

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -76,6 +76,14 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
       }
     }
 
+    const afterDateCondition = searchBuilderCriteria?.dateConditions?.['>']
+    if (afterDateCondition) {
+      afterDateCondition.search = (value: string, comparison: string[]) => {
+        value = value.replace(/(\/|-|,)/g, '-')
+        return value.length > 0 && value >= comparison[0]
+      }
+    }
+
     let dt!: Api<Product>
     setDt(
       () =>

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -57,6 +57,25 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
       return `${date.toLocaleDateString()}<br>${time}`
     }
 
+    const searchBuilderCriteria = (
+      DataTable as typeof DataTable & {
+        Criteria?: {
+          dateConditions?: Record<
+            string,
+            { search?: (value: string, comparison: string[]) => boolean }
+          >
+        }
+      }
+    ).Criteria
+
+    const beforeDateCondition = searchBuilderCriteria?.dateConditions?.['<']
+    if (beforeDateCondition) {
+      beforeDateCondition.search = (value: string, comparison: string[]) => {
+        value = value.replace(/(\/|-|,)/g, '-')
+        return value.length > 0 && value < comparison[0]
+      }
+    }
+
     let dt!: Api<Product>
     setDt(
       () =>
@@ -197,7 +216,11 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                 return btn as unknown as string
               },
             },
-            { title: 'Exp. Date', data: 'expiry_date', type: 'date' },
+            {
+              title: 'Exp. Date',
+              data: 'expiry_date',
+              type: 'date',
+            },
             {
               title: '',
               orderable: false,

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -48,7 +48,13 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
 
       if (type !== 'display') return String(data)
 
-      return `${date.toLocaleDateString()}<br>${date.toLocaleTimeString()}`
+      const time = date.toLocaleTimeString(undefined, {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      })
+
+      return `${date.toLocaleDateString()}<br>${time}`
     }
 
     let dt!: Api<Product>

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -33,14 +33,28 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
       return String(data) // Raw ISO date for SearchBuilder filter + correct sorting
     }
 
+    const displayDateTime = (data: unknown, type: string): string => {
+      if (!data) return type === 'display' ? '-' : ''
+      if (type !== 'display') return String(data)
+
+      const date = new Date(String(data))
+      if (Number.isNaN(date.getTime())) return String(data)
+
+      return `${date.toLocaleDateString()}<br>${date.toLocaleTimeString()}`
+    }
+
     let dt!: Api<Product>
     setDt(
       () =>
         (dt = new DataTable<Product>(tableRef, {
           columnDefs: [
             {
-              targets: [7, 9],
+              targets: [7],
               render: displayDate,
+            },
+            {
+              targets: [9],
+              render: displayDateTime,
             },
             {
               targets: [10],

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,4 +1,4 @@
-import { onCleanup, onMount, type Setter } from 'solid-js'
+import { createEffect, onCleanup, onMount, type Accessor, type Setter } from 'solid-js'
 import { redeem, fetchActivatedDate, setActivatedDate, type Product } from '../util'
 import DataTable, { type Api } from 'datatables.net-dt'
 import { hm } from '@violentmonkey/dom'
@@ -6,7 +6,15 @@ import { hm } from '@violentmonkey/dom'
 import styles from '../style.module.css'
 import { showToast } from '@violentmonkey/ui'
 
-export function Table({ products, setDt }: { products: Product[]; setDt: Setter<Api<Product>> }) {
+export function Table({
+  products,
+  setDt,
+  useLocalTime,
+}: {
+  products: Product[]
+  setDt: Setter<Api<Product>>
+  useLocalTime: Accessor<boolean>
+}) {
   let tableRef!: HTMLTableElement
 
   onMount(() => {
@@ -28,21 +36,26 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
       if (Number.isNaN(date.getTime())) return String(data)
 
       if (type === 'filter') {
-        const year = date.getFullYear()
-        const month = String(date.getMonth() + 1).padStart(2, '0')
-        const day = String(date.getDate()).padStart(2, '0')
+        const year = useLocalTime() ? date.getFullYear() : date.getUTCFullYear()
+        const month = String((useLocalTime() ? date.getMonth() : date.getUTCMonth()) + 1).padStart(
+          2,
+          '0'
+        )
+        const day = String(useLocalTime() ? date.getDate() : date.getUTCDate()).padStart(2, '0')
         return `${year}-${month}-${day}`
       }
 
       if (type !== 'display') return String(data)
 
+      const dateOptions = useLocalTime() ? undefined : { timeZone: 'UTC' }
       const time = date.toLocaleTimeString(undefined, {
         hour: '2-digit',
         minute: '2-digit',
         hour12: false,
+        ...dateOptions,
       })
 
-      return `${date.toLocaleDateString()}<br>${time}`
+      return `${date.toLocaleDateString(undefined, dateOptions)}<br>${time}`
     }
 
     const searchBuilderCriteria = (
@@ -329,6 +342,11 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
           },
         }))
     )
+
+    createEffect(() => {
+      useLocalTime()
+      dt.rows().invalidate().draw(false)
+    })
 
     // Warnings when selecting certain column filters
 

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -12,10 +12,6 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
   onMount(() => {
     console.debug('Mounting table with', products.length, 'products')
 
-    // Cast: TypeScript thinks render.date() isn't callable
-    type DtRender<T> = (data: unknown, type: string, row: T, meta: unknown) => string
-    const dtDate = DataTable.render.date() as unknown as DtRender<Product>
-
     const renderCellValue = (data: unknown, type: string): string | undefined => {
       if (data == null || data === '') return type === 'display' ? '-' : ''
       if (type !== 'display') return String(data)
@@ -24,14 +20,6 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
 
     const displayDash = (data: unknown, type: string): string =>
       !data ? (type === 'display' ? '-' : '') : String(data)
-
-    const displayDate = (data: unknown, type: string, row: Product, meta: unknown): string => {
-      if (!data) return type === 'display' ? '-' : ''
-
-      if (type === 'display') return dtDate(data, type, row, meta) // Formatted date for display
-
-      return String(data) // Raw ISO date for SearchBuilder filter + correct sorting
-    }
 
     const displayDateTime = (data: unknown, type: string): string => {
       if (!data) return type === 'display' ? '-' : ''
@@ -90,11 +78,7 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
         (dt = new DataTable<Product>(tableRef, {
           columnDefs: [
             {
-              targets: [7],
-              render: displayDate,
-            },
-            {
-              targets: [9],
+              targets: [7, 9],
               render: displayDateTime,
             },
             {


### PR DESCRIPTION
**Summary**

- Adds a `Local time` toggle to switch purchase and expiration date display between UTC and local time.
- Updates purchase and expiration date rendering to include consistent date and 24-hour time formatting.
- Fixes SearchBuilder date filtering so expiration dates are compared by day, empty expiration dates are ignored, and the selected day is included for “after” filters.
- Documents the new time zone toggle in the README.
- Bumps the package version to `0.5.1`.


Here are some test screenshots.

<img width="1020" height="299" alt="Snipaste-20260619154632412" src="https://github.com/user-attachments/assets/e4602d2e-7514-432e-b70a-b20a78b8f6ff" />
<img width="1020" height="299" alt="Snipaste-20260619154648790" src="https://github.com/user-attachments/assets/601cd28e-cddd-4036-825c-74004771f760" />
<img width="1020" height="325" alt="Snipaste-20260619154723839" src="https://github.com/user-attachments/assets/e35f204e-964f-43c6-a54d-26850d3d1acf" />
<img width="1020" height="344" alt="Snipaste-20260619154744122" src="https://github.com/user-attachments/assets/1522d1d9-e6b9-4370-8a12-f1bb34211202" />
<img width="1020" height="344" alt="Snipaste-20260619154836806" src="https://github.com/user-attachments/assets/2697f534-60a2-4318-b832-ac22ddf36965" />
<img width="1020" height="344" alt="Snipaste-20260619154855538" src="https://github.com/user-attachments/assets/e47bdaf4-f37a-4e99-b500-4e5fc986f0e5" />
<img width="1020" height="344" alt="image" src="https://github.com/user-attachments/assets/d0ba4a51-c01d-48a3-92a5-64d215f8f28c" />
