### PR TITLE
feat: improve redeemed date tracking and table behavior

### DIFF
--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -16,11 +16,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product>> }) {
   const exportASF = (products: Product[]) => {
     const keys = products
       .filter(
-        (product) =>
-          !product.is_gift &&
-          product.redeemed_key_val &&
-          !product.is_expired &&
-          product.key_type === 'steam'
+        (product) => !product.is_gift && product.redeemed_key_val && product.key_type === 'steam'
       )
       .map((product) => `${product.human_name}\t${product.redeemed_key_val}`)
       .join('\n')
@@ -49,6 +45,11 @@ export function Actions({ dt }: { dt: Accessor<Api<Product>> }) {
     return needsQuotes ? `"${s.replace(/"/g, '""')}"` : s
   }
 
+  const serializeField = (value: unknown): string => {
+    if (value == null) return ''
+    return String(value)
+  }
+
   const exportCSV = (products: Product[]) => {
     if (!products.length) {
       navigator.clipboard.writeText('')
@@ -56,12 +57,23 @@ export function Actions({ dt }: { dt: Accessor<Api<Product>> }) {
     }
 
     const delim = separator() || ','
-    const header = Object.keys(products[0])
+    const header = Object.keys(products[0]).flatMap((h) =>
+      h === 'redeemed_date' ? ['redeemed_date_label', 'redeemed_date_iso'] : [h]
+    )
+
+    const getCsvValue = (product: Product, header: string): unknown => {
+      if (header === 'redeemed_date_label') return product.redeemed_date?.label ?? ''
+      if (header === 'redeemed_date_iso') return product.redeemed_date?.iso ?? ''
+
+      return product[header as keyof Product]
+    }
 
     const lines = [
       header.map((h) => escapeCsvField(h, delim)).join(delim),
       ...products.map((product) =>
-        header.map((h) => escapeCsvField(product[h], delim)).join(delim)
+        header
+          .map((h) => escapeCsvField(serializeField(getCsvValue(product, h)), delim))
+          .join(delim)
       ),
     ]
 

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,5 +1,5 @@
 import { onCleanup, onMount, type Setter } from 'solid-js'
-import { redeem, fetchActivatedDate, setActivatedDate, type Product } from '../util'
+import { redeem, fetchRedeemedDate, setRedeemedDate, type Product } from '../util'
 import DataTable, { type Api } from 'datatables.net-dt'
 import { hm } from '@violentmonkey/dom'
 // @ts-expect-error missing types
@@ -27,11 +27,16 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
 
     const displayDate = (data: unknown, type: string, row: Product, meta: unknown): string => {
       if (!data) return type === 'display' ? '-' : ''
-
       if (type === 'display') return dtDate(data, type, row, meta) // Formatted date for display
-
       return String(data) // Raw ISO date for SearchBuilder filter + correct sorting
     }
+
+    const displayDateOnly = (iso: string): string =>
+      iso.replace(/^(\d{4})-(\d{2})-(\d{2})$/, (_, y, m, d) => `${Number(m)}/${Number(d)}/${y}`)
+
+    /** Steam Support URL for a given appId */
+    const steamSupportUrl = (appId: number) =>
+      `https://help.steampowered.com/en/wizard/HelpWithGame?appid=${appId}`
 
     let dt!: Api<Product>
     setDt(
@@ -121,39 +126,61 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
             },
             { title: 'Purchased', data: 'created', type: 'date' },
             {
-              title: 'Activated',
+              // ---------------------------------------------------------------
+              // "Redeemed" column — Steam Support app-level data
+              // ---------------------------------------------------------------
+              title: 'Redeemed',
               data: null,
-              type: 'string-utf8',
-              render: (data, type, row) => {
-                if (!row.steam_app_id || row.owned !== 'Yes') {
-                  return type === 'display' ? '-' : ''
+              type: 'date',
+              className: 'dt-right',
+              render: (_, type, row) => {
+                // For SearchBuilder / sorting: emit only the ISO date string so
+                // DataTables never sees the display label text.
+                if (type !== 'display') {
+                  return row.redeemed_date?.iso ?? ''
                 }
 
-                if (row.activated_date) {
-                  return type === 'display' ? row.activated_date : row.activated_date
+                // ── Already fetched ─────────────────────────────────────────
+                if (row.redeemed_date) {
+                  const { label, iso } = row.redeemed_date
+                  return hm('a', {
+                    href: steamSupportUrl(row.steam_app_id!),
+                    target: '_blank',
+                    title: 'Open Steam Support page',
+                    innerText: `${label}: ${displayDateOnly(iso)}`,
+                  }) as unknown as string
                 }
 
-                if (type !== 'display') return ''
+                // ── Not owned on this Steam account — nothing to show ───────────────────
+                if (!row.steam_app_id || row.owned !== 'Yes') return '-'
 
-                const btn = hm(
+                // ── Not yet fetched: show a fetch button ────────────────────────────────
+                const fetchBtn = hm(
                   'button',
                   {
                     class: styles.btn,
                     type: 'button',
-                    title: 'Fetch activation date from Steam',
+                    title: 'Fetch redeemed date from Steam Support',
                     onclick: async (e: MouseEvent) => {
                       const target = e.currentTarget as HTMLButtonElement
                       target.disabled = true
                       target.innerHTML = '<i class="hb hb-spin hb-spinner"></i>'
                       try {
-                        const date = await fetchActivatedDate(row.steam_app_id!)
-                        if (date) {
-                          setActivatedDate(row.steam_app_id!, date)
-                          row.activated_date = date
-                          target.parentElement!.textContent = date
-                          dt.rows().invalidate().draw(false)
+                        const result = await fetchRedeemedDate(row.steam_app_id!)
+                        if (result) {
+                          const appId = row.steam_app_id!
+
+                          setRedeemedDate(appId, result)
+
+                          for (const product of products) {
+                            if (product.steam_app_id === appId) {
+                              product.redeemed_date = result
+                            }
+                          }
+
+                          dt.rows().invalidate('data').draw('page')
                         } else {
-                          showToast('No activation date found')
+                          showToast('No redeemed date found on Steam Support page')
                           target.disabled = false
                           target.innerHTML = '<i class="hb hb-clock"></i>'
                         }
@@ -166,7 +193,24 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                   },
                   hm('i', { class: 'hb hb-clock' })
                 )
-                return btn as unknown as string
+
+                // ── Not yet fetched: show Steam Support link + fetch button ──────────────
+                const supportLink = hm(
+                  'a',
+                  {
+                    class: styles.btn,
+                    href: steamSupportUrl(row.steam_app_id),
+                    target: '_blank',
+                    title: 'Open Steam Support page',
+                    style: 'margin-right:2px;',
+                  },
+                  hm('i', { class: 'hb hb-steam' })
+                )
+
+                return hm('span', { class: styles.redeemed_actions }, [
+                  supportLink,
+                  fetchBtn,
+                ]) as unknown as string
               },
             },
             { title: 'Exp. Date', data: 'expiry_date', type: 'date' },
@@ -195,12 +239,7 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                   )
                 }
 
-                if (
-                  row.redeemed_key_val &&
-                  !row.is_gift &&
-                  !row.is_expired &&
-                  row.key_type === 'steam'
-                ) {
+                if (row.redeemed_key_val && !row.is_gift && row.key_type === 'steam') {
                   actions.push(
                     hm(
                       'a',
@@ -312,9 +351,15 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
     const warnings: WarningRule[] = [
       {
         element: makeWarning(
-          '⚠️ "Owned" column: Keys containing packages can incorrectly appear owned when only the base game is owned. This column may also contain many null values.'
+          '⚠️ "Owned" column: Keys containing multiple app IDs/content can incorrectly appear owned because only one app ID is returned by Humble\'s API. This column may also contain many null values.'
         ),
         show: (selectedColumns) => selectedColumns.includes('Owned'),
+      },
+      {
+        element: makeWarning(
+          '⚠️ "Redeemed" column uses Steam Support app ID data, which may be inaccurate when the key\'s package (sub ID) contains more than one app ID.'
+        ),
+        show: (selectedColumns) => selectedColumns.includes('Redeemed'),
       },
     ]
 

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -21,6 +21,23 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
     const displayDash = (data: unknown, type: string): string =>
       !data ? (type === 'display' ? '-' : '') : String(data)
 
+    const displayYesNoBadge = (
+      data: unknown,
+      type: string,
+      noClassName = styles.no_badge
+    ): string => {
+      const value = displayDash(data, type)
+
+      if (type !== 'display' || (value !== 'Yes' && value !== 'No')) {
+        return value
+      }
+
+      return hm('span', {
+        class: `${styles.yes_no_badge} ${value === 'Yes' ? styles.yes_badge : noClassName}`,
+        innerText: value,
+      }) as unknown as string
+    }
+
     const displayDateOnly = (iso: string): string =>
       iso.replace(/^(\d{4})-(\d{2})-(\d{2})$/, (_, y, m, d) => `${Number(m)}/${Number(d)}/${y}`)
 
@@ -224,12 +241,13 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
               title: 'Revealed',
               data: (row: Product) => (row.is_gift || row.redeemed_key_val ? 'Yes' : 'No'),
               type: 'string-utf8',
+              render: (data, type) => displayYesNoBadge(data, type, styles.warning_badge),
             },
             {
               title: 'Owned',
               data: 'owned',
               type: 'string-utf8',
-              render: displayDash,
+              render: displayYesNoBadge,
             },
             { title: 'Purchased', data: 'created', type: 'date' },
             {

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -24,12 +24,29 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
     const displayDateOnly = (iso: string): string =>
       iso.replace(/^(\d{4})-(\d{2})-(\d{2})$/, (_, y, m, d) => `${Number(m)}/${Number(d)}/${y}`)
 
+    const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    })
+
     const isUtcDateMarker = (value: string): boolean =>
       /^\d{4}-\d{2}-\d{2}T00:00:00\.000Z$/.test(value)
 
     const parseDate = (value: unknown): Date | null => {
       const date = new Date(String(value))
       return Number.isNaN(date.getTime()) ? null : date
+    }
+
+    const displayDateTime = (value: unknown): string => {
+      const s = String(value)
+
+      if (isUtcDateMarker(s)) return displayDateOnly(s.slice(0, 10))
+
+      const date = parseDate(s)
+      return date ? dateTimeFormatter.format(date) : s
     }
 
     const localDateKey = (value: unknown): string => {
@@ -53,11 +70,7 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
 
       if (type === 'filter') return localDateKey(s)
 
-      if (type === 'display') {
-        return isUtcDateMarker(s)
-          ? displayDateOnly(s.slice(0, 10))
-          : (parseDate(s)?.toLocaleDateString() ?? s)
-      }
+      if (type === 'display') return displayDateTime(s)
 
       return s
     }

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -12,10 +12,6 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
   onMount(() => {
     console.debug('Mounting table with', products.length, 'products')
 
-    // Cast: TypeScript thinks render.date() isn't callable
-    type DtRender<T> = (data: unknown, type: string, row: T, meta: unknown) => string
-    const dtDate = DataTable.render.date() as unknown as DtRender<Product>
-
     const renderCellValue = (data: unknown, type: string): string | undefined => {
       if (data == null || data === '') return type === 'display' ? '-' : ''
       if (type !== 'display') return String(data)
@@ -25,18 +21,116 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
     const displayDash = (data: unknown, type: string): string =>
       !data ? (type === 'display' ? '-' : '') : String(data)
 
-    const displayDate = (data: unknown, type: string, row: Product, meta: unknown): string => {
-      if (!data) return type === 'display' ? '-' : ''
-      if (type === 'display') return dtDate(data, type, row, meta) // Formatted date for display
-      return String(data) // Raw ISO date for SearchBuilder filter + correct sorting
-    }
-
     const displayDateOnly = (iso: string): string =>
       iso.replace(/^(\d{4})-(\d{2})-(\d{2})$/, (_, y, m, d) => `${Number(m)}/${Number(d)}/${y}`)
+
+    const isUtcDateMarker = (value: string): boolean =>
+      /^\d{4}-\d{2}-\d{2}T00:00:00\.000Z$/.test(value)
+
+    const parseDate = (value: unknown): Date | null => {
+      const date = new Date(String(value))
+      return Number.isNaN(date.getTime()) ? null : date
+    }
+
+    const localDateKey = (value: unknown): string => {
+      const s = String(value)
+      if (isUtcDateMarker(s)) return s.slice(0, 10)
+
+      const date = parseDate(s)
+      if (!date) return s
+
+      const year = date.getFullYear()
+      const month = String(date.getMonth() + 1).padStart(2, '0')
+      const day = String(date.getDate()).padStart(2, '0')
+
+      return `${year}-${month}-${day}`
+    }
+
+    const displayDate = (data: unknown, type: string): string => {
+      if (!data) return type === 'display' ? '-' : ''
+
+      const s = String(data)
+
+      if (type === 'filter') return localDateKey(s)
+
+      if (type === 'display') {
+        return isUtcDateMarker(s)
+          ? displayDateOnly(s.slice(0, 10))
+          : (parseDate(s)?.toLocaleDateString() ?? s)
+      }
+
+      return s
+    }
 
     /** Steam Support URL for a given appId */
     const steamSupportUrl = (appId: number) =>
       `https://help.steampowered.com/en/wizard/HelpWithGame?appid=${appId}`
+
+    const searchDateKey = (value: string): string => {
+      const s = value.trim()
+      if (!s) return ''
+      if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return s
+
+      return localDateKey(s)
+    }
+
+    type DateCondition = {
+      search?: (value: string, comparison: string[]) => boolean
+    }
+
+    const dateConditions = (
+      DataTable as typeof DataTable & {
+        Criteria?: {
+          dateConditions?: Record<string, DateCondition>
+        }
+      }
+    ).Criteria?.dateConditions
+
+    const setDateCondition = (
+      condition: string,
+      search: (value: string, comparison: string[]) => boolean
+    ): void => {
+      const dateCondition = dateConditions?.[condition]
+      if (dateCondition) dateCondition.search = search
+    }
+
+    setDateCondition('=', (value, comparison) => {
+      const left = searchDateKey(value)
+      const right = searchDateKey(comparison[0] ?? '')
+      return left !== '' && right !== '' && left === right
+    })
+
+    setDateCondition('!=', (value, comparison) => {
+      const left = searchDateKey(value)
+      const right = searchDateKey(comparison[0] ?? '')
+      return left !== '' && right !== '' && left !== right
+    })
+
+    setDateCondition('<', (value, comparison) => {
+      const left = searchDateKey(value)
+      const right = searchDateKey(comparison[0] ?? '')
+      return left !== '' && right !== '' && left < right
+    })
+
+    setDateCondition('>', (value, comparison) => {
+      const left = searchDateKey(value)
+      const right = searchDateKey(comparison[0] ?? '')
+      return left !== '' && right !== '' && left >= right
+    })
+
+    setDateCondition('between', (value, comparison) => {
+      const left = searchDateKey(value)
+      const min = searchDateKey(comparison[0] ?? '')
+      const max = searchDateKey(comparison[1] ?? '')
+      return left !== '' && min !== '' && max !== '' && left >= min && left <= max
+    })
+
+    setDateCondition('!between', (value, comparison) => {
+      const left = searchDateKey(value)
+      const min = searchDateKey(comparison[0] ?? '')
+      const max = searchDateKey(comparison[1] ?? '')
+      return left !== '' && min !== '' && max !== '' && (left < min || left > max)
+    })
 
     let dt!: Api<Product>
     setDt(

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -420,9 +420,37 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
         }))
     )
 
+    const container = dt.table().container() as HTMLElement
+
+    let pagingTop: number | null = null
+
+    const getPaging = () => container.querySelector<HTMLElement>('.dt-paging')
+
+    const rememberPagingTop = () => {
+      const rect = getPaging()?.getBoundingClientRect()
+
+      pagingTop = rect && rect.bottom > 0 && rect.top < window.innerHeight ? rect.top : null
+    }
+
+    const restorePagingTop = () => {
+      if (pagingTop == null) return
+
+      const previousTop = pagingTop
+      pagingTop = null
+
+      requestAnimationFrame(() => {
+        const nextTop = getPaging()?.getBoundingClientRect().top
+        if (nextTop != null) {
+          window.scrollBy({ top: nextTop - previousTop, behavior: 'auto' })
+        }
+      })
+    }
+
+    dt.on('page', rememberPagingTop)
+    dt.on('draw', restorePagingTop)
+
     // Warnings when selecting certain column filters
 
-    const container = dt.table().container() as HTMLElement
     const searchBuilderRoot = container.querySelector('.dtsb-searchBuilder') as HTMLElement | null
 
     type WarningRule = {
@@ -483,6 +511,9 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
     }
 
     onCleanup(() => {
+      dt.off('page', rememberPagingTop)
+      dt.off('draw', restorePagingTop)
+
       searchBuilderRoot?.removeEventListener('change', refreshWarnings)
       observer?.disconnect()
       for (const warning of warnings) warning.element.remove()

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -41,10 +41,13 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
     const displayDateOnly = (iso: string): string =>
       iso.replace(/^(\d{4})-(\d{2})-(\d{2})$/, (_, y, m, d) => `${Number(m)}/${Number(d)}/${y}`)
 
-    const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+    const dateFormatter = new Intl.DateTimeFormat(undefined, {
       year: 'numeric',
       month: 'numeric',
       day: 'numeric',
+    })
+
+    const timeFormatter = new Intl.DateTimeFormat(undefined, {
       hour: 'numeric',
       minute: '2-digit',
     })
@@ -63,7 +66,15 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
       if (isUtcDateMarker(s)) return displayDateOnly(s.slice(0, 10))
 
       const date = parseDate(s)
-      return date ? dateTimeFormatter.format(date) : s
+      if (!date) return s
+
+      const datePart = dateFormatter.format(date)
+      const timePart = timeFormatter.format(date)
+
+      return [
+        `<span class="${styles.date_time_part}">${datePart}</span>`,
+        `<span class="${styles.date_time_part}">${timePart}</span>`,
+      ].join(' ')
     }
 
     const localDateKey = (value: unknown): string => {
@@ -268,12 +279,21 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                 // ── Already fetched ─────────────────────────────────────────
                 if (row.redeemed_date) {
                   const { label, iso } = row.redeemed_date
-                  return hm('a', {
-                    href: steamSupportUrl(row.steam_app_id!),
-                    target: '_blank',
-                    title: 'Open Steam Support page',
-                    innerText: `${label}: ${displayDateOnly(iso)}`,
-                  }) as unknown as string
+                  return hm(
+                    'a',
+                    {
+                      href: steamSupportUrl(row.steam_app_id!),
+                      target: '_blank',
+                      title: 'Open Steam Support page',
+                    },
+                    [
+                      `${label}: `,
+                      hm('span', {
+                        class: styles.date_time_part,
+                        innerText: displayDateOnly(iso),
+                      }),
+                    ]
+                  ) as unknown as string
                 }
 
                 // ── Not owned on this Steam account — nothing to show ───────────────────

--- a/src/meta.js
+++ b/src/meta.js
@@ -14,4 +14,9 @@
 // @icon        https://www.google.com/s2/favicons?domain=humblebundle.com&sz=32
 // @downloadURL process.env.DOWNLOAD_URL
 // @homepageURL https://github.com/MrMarble/hb-key-exporter
+// @grant       GM_addStyle
+// @grant       GM_getResourceText
+// @grant       GM_xmlhttpRequest
+// @connect     store.steampowered.com
+// @connect     help.steampowered.com
 // ==/UserScript==

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -38,3 +38,9 @@ tr.expired {
   display: flex;
   gap: 2px;
 }
+
+.redeemed_actions {
+  display: inline-flex;
+  gap: 2px;
+  align-items: center;
+}

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -44,3 +44,29 @@ tr.expired {
   gap: 2px;
   align-items: center;
 }
+
+.yes_no_badge {
+  display: inline-block;
+  min-width: 3ch;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.4;
+  text-align: center;
+}
+
+.yes_badge {
+  background-color: #d1e7dd;
+  color: #0f5132;
+}
+
+.no_badge {
+  background-color: #e2e3e5;
+  color: #41464b;
+}
+
+.warning_badge {
+  background-color: #fff3cd;
+  color: #664d03;
+}

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -6,6 +6,10 @@ tr.expired {
   background-color: #f8d7da !important;
 }
 
+.date_time_part {
+  white-space: nowrap;
+}
+
 .select {
   padding: 5px 30px 5px 10px;
   border: 1px solid #ccc;

--- a/src/util.ts
+++ b/src/util.ts
@@ -134,7 +134,7 @@ const defaultHumanExpiry = (year: number, month: number, day: number): string =>
 
 function resolveExpiryDate(tpk: TpkLike): string {
   const direct = tpk.expiry_date?.trim()
-  if (direct) return normalizeHumbleExpiry(direct)
+  if (direct) return normalizeHumbleDateTime(direct)
 
   const html = tpk.custom_instructions_html?.trim()
   if (!html) return ''
@@ -148,7 +148,7 @@ function resolveExpiryDate(tpk: TpkLike): string {
   return parseExpiryFromText(text)
 }
 
-function normalizeHumbleExpiry(s: string): string {
+function normalizeHumbleDateTime(s: string): string {
   // already has an offset or Z → keep
   if (/[zZ]$|[+-]\d{2}:?\d{2}$/.test(s)) return new Date(s).toISOString()
 
@@ -293,6 +293,7 @@ export const getProducts = (orders: Order[], ownedApps: number[]): Product[] => 
   return orders.flatMap((order) =>
     order.tpkd_dict.all_tpks.map((product) => {
       const expiry = resolveExpiryDate(product)
+      const created = order.created ? normalizeHumbleDateTime(order.created) : ''
       const expiryMs = expiry ? Date.parse(expiry) : NaN
       const isExpired = product.is_expired || (!Number.isNaN(expiryMs) && expiryMs < Date.now())
 
@@ -309,7 +310,7 @@ export const getProducts = (orders: Order[], ownedApps: number[]): Product[] => 
         is_expired: isExpired,
         expiry_date: expiry,
         steam_app_id: product.steam_app_id,
-        created: order.created || '',
+        created,
         keyindex: product.keyindex,
         owned: product.steam_app_id
           ? ownedApps.includes(product.steam_app_id)

--- a/src/util.ts
+++ b/src/util.ts
@@ -27,6 +27,14 @@ export interface Order {
   }
 }
 
+/** Structured result from Steam Support for the Redeemed column. */
+export interface RedeemedDate {
+  /** "Activated" | "Purchased" — the label shown on Steam Support */
+  label: 'Activated' | 'Purchased'
+  /** ISO 8601 date-only string, e.g. "2023-04-15", used for sorting/filtering */
+  iso: string
+}
+
 export interface Product {
   machine_name: string
   category: 'Store' | 'Bundle' | 'Other' | 'Choice'
@@ -43,7 +51,8 @@ export interface Product {
   steam_app_id?: number
   created: string
   keyindex?: number
-  activated_date?: string
+  /** Stored structured result from Steam Support */
+  redeemed_date?: RedeemedDate
 }
 
 type TpkLike = Pick<
@@ -85,17 +94,29 @@ const TZ_ALIASES: Array<[string, string]> = [
 
 const MONTHS: Record<string, number> = {
   january: 1,
+  jan: 1,
   february: 2,
+  feb: 2,
   march: 3,
+  mar: 3,
   april: 4,
+  apr: 4,
   may: 5,
   june: 6,
+  jun: 6,
   july: 7,
+  jul: 7,
   august: 8,
+  aug: 8,
   september: 9,
+  sep: 9,
+  sept: 9,
   october: 10,
+  oct: 10,
   november: 11,
+  nov: 11,
   december: 12,
+  dec: 12,
 }
 
 const DEFAULT_HUMAN_TZ = 'America/Los_Angeles'
@@ -160,7 +181,7 @@ function parseExpiryFromText(text: string): string {
   const day = Number(dayStr)
   const year = Number(yearStr)
 
-  // No time provided → return ISO date only (don’t invent precision)
+  // No time provided → return ISO date only (don't invent precision)
   if (!tailRaw) return `${year}-${pad2(month)}-${pad2(day)}`
 
   // Parse time + optional timezone phrase/abbr
@@ -256,7 +277,7 @@ export const loadOrders = () =>
     .filter((order) => order?.tpkd_dict?.all_tpks?.length)
 
 export const getProducts = (orders: Order[], ownedApps: number[]): Product[] => {
-  const activatedMap = loadActivatedDatesMap()
+  const redeemedMap = loadRedeemedDatesMap()
 
   return orders.flatMap((order) =>
     order.tpkd_dict.all_tpks.map((product) => {
@@ -284,8 +305,8 @@ export const getProducts = (orders: Order[], ownedApps: number[]): Product[] => 
             ? 'Yes'
             : 'No'
           : '',
-        activated_date: product.steam_app_id
-          ? (activatedMap[String(product.steam_app_id)] ?? undefined)
+        redeemed_date: product.steam_app_id
+          ? (redeemedMap[String(product.steam_app_id)] ?? undefined)
           : undefined,
       }
     })
@@ -330,7 +351,6 @@ const fetchOwnedApps = async (): Promise<number[]> =>
           reject(new Error(`HTTP ${res.status}`))
           return
         }
-
         resolve(res)
       },
       onerror: (err) => {
@@ -353,43 +373,87 @@ const fetchOwnedApps = async (): Promise<number[]> =>
       return []
     })
 
-const ACTIVATED_DATES_KEY = 'hb-key-exporter:activated-dates'
+// ---------------------------------------------------------------------------
+// Redeemed date — Steam Support app-level data
+// ---------------------------------------------------------------------------
 
-const loadActivatedDatesMap = (): Record<string, string> => {
+const REDEEMED_DATES_KEY = 'hb-key-exporter:redeemed-dates'
+
+const loadRedeemedDatesMap = (): Record<string, RedeemedDate> => {
   try {
-    const data = localStorage.getItem(ACTIVATED_DATES_KEY)
+    const data = localStorage.getItem(REDEEMED_DATES_KEY)
     return data ? JSON.parse(data) : {}
   } catch {
     return {}
   }
 }
 
-export const setActivatedDate = (appId: number, date: string): void => {
+export const setRedeemedDate = (appId: number, entry: RedeemedDate): void => {
   try {
-    const data = localStorage.getItem(ACTIVATED_DATES_KEY)
-    const map: Record<string, string> = data ? JSON.parse(data) : {}
-    map[String(appId)] = date
-    localStorage.setItem(ACTIVATED_DATES_KEY, JSON.stringify(map))
+    const data = localStorage.getItem(REDEEMED_DATES_KEY)
+    const map: Record<string, RedeemedDate> = data ? JSON.parse(data) : {}
+    map[String(appId)] = entry
+    localStorage.setItem(REDEEMED_DATES_KEY, JSON.stringify(map))
   } catch (e) {
-    console.error('Failed to store activated date:', e)
+    console.error('Failed to store redeemed date:', e)
   }
 }
 
-export const fetchActivatedDate = async (appId: number): Promise<string | null> => {
+/**
+ * Parse a human-readable Steam date string like "4 Apr, 2023" → "YYYY-MM-DD".
+ * Falls back to the original string (untouched) if parsing fails, so the
+ * caller can still surface something useful in the display label.
+ */
+function parseSteamDateToIso(raw: string): string {
+  const m = raw.trim().match(/\b([A-Za-z]{3,9})\.?\s+(\d{1,2})(?:,\s*(\d{4}))?\b/)
+  if (!m) return ''
+
+  const month = MONTHS[m[1].toLowerCase()]
+  const day = Number(m[2])
+  const year = m[3] ? Number(m[3]) : new Date().getFullYear()
+
+  if (!month || !day || day < 1 || day > 31) return ''
+
+  return `${year}-${pad2(month)}-${pad2(day)}`
+}
+
+export const fetchRedeemedDate = async (appId: number): Promise<RedeemedDate | null> => {
   const html = await new Promise<string>((resolve, reject) => {
     GM_xmlhttpRequest({
       url: `https://help.steampowered.com/en/wizard/HelpWithGame?appid=${appId}`,
       method: 'GET',
       timeout: 10000,
       onload: (res) => {
+        if (res.status === 401 || res.status === 403) {
+          reject(
+            new Error(
+              `Steam login required (HTTP ${res.status}). ` +
+                `Open the Steam Support page for this app, log in, then try again.`
+            )
+          )
+          return
+        }
         if (res.status !== 200) {
-          reject(new Error(`HTTP ${res.status}`))
+          reject(
+            new Error(
+              `Steam Support returned HTTP ${res.status}. ` +
+                `This may be a missing @connect permission, a network issue, ` +
+                `or Steam blocking the request. Check the browser console.`
+            )
+          )
           return
         }
         resolve(res.responseText)
       },
-      onerror: () => reject(new Error('Request failed')),
-      ontimeout: () => reject(new Error('Request timed out')),
+      onerror: () =>
+        reject(
+          new Error(
+            `Request failed. Possible causes: the @connect help.steampowered.com permission ` +
+              `has not been granted yet (approve it in your userscript manager), ` +
+              `a network/CORS error, or Steam is temporarily unavailable.`
+          )
+        ),
+      ontimeout: () => reject(new Error('Request timed out after 10 s')),
     })
   })
 
@@ -400,10 +464,19 @@ export const fetchActivatedDate = async (appId: number): Promise<string | null> 
     const divs = accountDetails.querySelectorAll('div')
     for (const div of divs) {
       const label = div.querySelector('.help_highlight_text')
-      const text = label?.textContent?.trim() ?? ''
-      if (text === 'Activated:' || text === 'Purchased:') {
+      const labelText = label?.textContent?.trim() ?? ''
+      if (labelText === 'Activated:' || labelText === 'Purchased:') {
         const value = div.querySelector('.help_lowlight_text')
-        if (value?.textContent) return value.textContent.trim()
+        const raw = value?.textContent?.trim()
+        if (raw) {
+          const iso = parseSteamDateToIso(raw)
+          if (iso) {
+            return {
+              label: labelText === 'Activated:' ? 'Activated' : 'Purchased',
+              iso,
+            }
+          }
+        }
       }
     }
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -123,6 +123,15 @@ const DEFAULT_HUMAN_TZ = 'America/Los_Angeles'
 
 const pad2 = (n: number) => String(n).padStart(2, '0')
 
+const utcDateMarker = (year: number, month: number, day: number): string =>
+  new Date(Date.UTC(year, month - 1, day, 0, 0, 0)).toISOString()
+
+const defaultHumanExpiry = (year: number, month: number, day: number): string =>
+  zonedTimeToUtc(
+    { year, month, day, hour: 23, minute: 59, second: 59 },
+    DEFAULT_HUMAN_TZ
+  ).toISOString()
+
 function resolveExpiryDate(tpk: TpkLike): string {
   const direct = tpk.expiry_date?.trim()
   if (direct) return normalizeHumbleExpiry(direct)
@@ -143,16 +152,16 @@ function normalizeHumbleExpiry(s: string): string {
   // already has an offset or Z → keep
   if (/[zZ]$|[+-]\d{2}:?\d{2}$/.test(s)) return new Date(s).toISOString()
 
-  // date-only YYYY-MM-DD → interpret as PT end-of-day, convert to UTC ISO
+  // API date-only YYYY-MM-DD → encode as a UTC midnight datetime
   const d = s.match(/^(\d{4})-(\d{2})-(\d{2})$/)
   if (d) {
     const year = Number(d[1]),
       month = Number(d[2]),
       day = Number(d[3])
-    return new Date(Date.UTC(year, month - 1, day, 23, 59, 59)).toISOString()
+    return utcDateMarker(year, month, day)
   }
 
-  // "YYYY-MM-DDTHH:mm:ss" or "YYYY-MM-DD HH:mm:ss" → interpret as PT, convert
+  // API datetime without an offset → treat as UTC and normalize
   const dt = s.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})(?::(\d{2}))?/)
   if (dt) {
     const year = Number(dt[1]),
@@ -181,13 +190,15 @@ function parseExpiryFromText(text: string): string {
   const day = Number(dayStr)
   const year = Number(yearStr)
 
-  // No time provided → return ISO date only (don't invent precision)
-  if (!tailRaw) return `${year}-${pad2(month)}-${pad2(day)}`
+  // No time provided → assume end of day in Pacific and convert to UTC
+  if (!tailRaw) return defaultHumanExpiry(year, month, day)
 
   // Parse time + optional timezone phrase/abbr
   const t = tailRaw.trim()
   const tm = t.match(/(\d{1,2})(?::(\d{2}))?(?::(\d{2}))?\s*(AM|PM)\s*(.*)?/i)
-  if (!tm) return `${year}-${pad2(month)}-${pad2(day)}`
+
+  // No time provided → assume end of day in Pacific and convert to UTC
+  if (!tm) return defaultHumanExpiry(year, month, day)
 
   const [, hh, mm = '0', ss = '0', ampm, tzRest = ''] = tm
   let hour = Number(hh)
@@ -198,7 +209,7 @@ function parseExpiryFromText(text: string): string {
   if (hour === 12) hour = isPM ? 12 : 0
   else if (isPM) hour += 12
 
-  const timeZone = pickIanaTimeZone(tzRest) // defaults to UTC if unknown/empty
+  const timeZone = pickIanaTimeZone(tzRest) // defaults to Pacific if unknown/empty
   const utc = zonedTimeToUtc({ year, month, day, hour, minute, second }, timeZone)
   return utc.toISOString()
 }


### PR DESCRIPTION
## Summary

This replaces the `Activated` column with a more accurate `Redeemed` column using Steam Support data.

`Redeemed` is meant as an umbrella label for Steam Support's `Activated` and `Purchased` dates. Steam shows either one depending on how the game was added to the account, so this stores both the label and the parsed date instead of treating every result as an activation date.

Fetched redeemed dates are saved by Steam app ID and reused for matching rows. The table displays them as date-only values to avoid timezone shifting, and updates matching rows without forcing an immediate re-sort.

This also fixes table date filtering and keeps pagination stable when page changes alter row heights.

## Changes

- Replace `Activated` column with `Redeemed`.
- Store Steam Support results as separate label and ISO date fields.
- Reuse saved redeemed dates across rows with the same Steam app ID.
- Add a Steam Support link next to the fetch button so users can verify the source page and refresh their Steam Support session before fetching, since the request may fail unless Steam Support was recently visited.
- Export redeemed label/date fields separately in CSV.
- Include expired revealed Steam keys in ASF export.
- Keep Steam redeem links visible for expired revealed keys.
- Add the needed userscript permissions for Steam Support requests.
- Clarify the warnings for `Owned` and `Redeemed` app-ID limitations.
- Add status badges for `Revealed` and `Owned` values, highlighting unrevealed keys and confirmed owned apps without over-coloring unowned rows.
- Fix local-date filtering for table date columns.
  Closes #35.
- Display `Purchased` and `Exp. Date` with local times while preserving UTC ISO values for sorting and CSV export.
- Keep date/time display parts together so local timestamps and redeemed-date labels wrap cleanly at narrow column widths.
- Treat human-readable Humble expiration dates without a time as end-of-day Pacific before converting to UTC.
- Keep the pagination controls anchored when changing pages, even when row heights change due to wrapping or overflowing titles.

## Notes

The `Redeemed` column still uses Steam app-level data. It can be wrong for keys that redeem a package or sub ID containing multiple app IDs, because Humble only gives us one Steam app ID to check (or none if the `steam_app_id` API field returns `null`).