### PR TITLE
feat(table): improve Steam data integration, toasts, and UX

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,7 +1,9 @@
-import { createResource, createSignal, Show } from 'solid-js'
+import { createResource, createSignal, onCleanup, onMount, Show } from 'solid-js'
 import {
   clearSteamAccountNotice,
+  clearSteamNotices,
   clearSteamOwnedNotice,
+  fetchSteamAccountId,
   getProducts,
   loadOrders,
   loadOwnedApps,
@@ -21,9 +23,27 @@ export function App() {
   const [pendingSteamOwnedNoticeUsedCache, setPendingSteamOwnedNoticeUsedCache] =
     createSignal(false)
   const [pendingSteamAccountNotice, setPendingSteamAccountNotice] = createSignal(false)
+  const [steamId, setSteamId] = createSignal<string | null>(null)
+
+  let checkSteamAccountTimer: number | undefined
 
   const refreshAfterSteamPageOpen = () => {
     window.setTimeout(() => refreshProducts(), 3000)
+  }
+
+  const checkSteamAccountChanged = () => {
+    if (!open()) return
+
+    window.clearTimeout(checkSteamAccountTimer)
+
+    checkSteamAccountTimer = window.setTimeout(async () => {
+      const account = await fetchSteamAccountId()
+
+      if (!account.loadFailed && account.steamId !== steamId()) {
+        clearSteamNotices()
+        refreshProducts()
+      }
+    }, 750)
   }
 
   const showOwnedNotice = (usedCache: boolean) => {
@@ -37,6 +57,10 @@ export function App() {
   const toggleOpen = () => {
     const next = !open()
     setOpen(next)
+
+    if (next) {
+      checkSteamAccountChanged()
+    }
 
     if (next && pendingSteamAccountNotice()) {
       setPendingSteamAccountNotice(false)
@@ -54,6 +78,7 @@ export function App() {
       console.debug('Loading products...')
       const orders = loadOrders()
       const owned = await loadOwnedApps(info.refetching)
+      setSteamId(owned.steamId)
 
       if (owned.accountLoadFailed) {
         if (open()) {
@@ -86,11 +111,27 @@ export function App() {
         owned.apps?.length ?? 'unavailable',
         'owned apps'
       )
-      return getProducts(orders, owned.apps)
+      return getProducts(orders, owned.apps, owned.steamId)
     }
   )
 
   const [dt, setDt] = createSignal<Api<Product> | null>(null)
+
+  onMount(() => {
+    const checkSteamAccountChangedAfterVisibility = () => {
+      if (!document.hidden) checkSteamAccountChanged()
+    }
+
+    window.addEventListener('focus', checkSteamAccountChanged)
+    document.addEventListener('visibilitychange', checkSteamAccountChangedAfterVisibility)
+
+    onCleanup(() => {
+      window.clearTimeout(checkSteamAccountTimer)
+      window.removeEventListener('focus', checkSteamAccountChanged)
+      document.removeEventListener('visibilitychange', checkSteamAccountChangedAfterVisibility)
+    })
+  })
+
   console.debug('App loaded')
 
   return (
@@ -108,8 +149,8 @@ export function App() {
         <div style={{ display: 'flex', 'justify-content': 'end', 'align-items': 'center' }}>
           <Refresh refresh={refreshProducts} />
         </div>
-        <Show when={products()?.length} fallback={<p>Loading products...</p>}>
-          <Table products={products()} setDt={setDt} />
+        <Show when={products()} keyed fallback={<p>Loading products...</p>}>
+          {(loadedProducts) => <Table products={loadedProducts} steamId={steamId} setDt={setDt} />}
         </Show>
         <Actions dt={dt} />
       </div>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,14 @@
 import { createResource, createSignal, Show } from 'solid-js'
-import { getProducts, loadOrders, loadOwnedApps, type Product } from './util'
+import {
+  clearSteamAccountNotice,
+  clearSteamOwnedNotice,
+  getProducts,
+  loadOrders,
+  loadOwnedApps,
+  showSteamAccountNotice,
+  showSteamOwnedNotice,
+  type Product,
+} from './util'
 
 import { Table } from './components/Table'
 import { Refresh } from './components/Refresh'
@@ -8,15 +17,78 @@ import type { Api } from 'datatables.net-dt'
 
 export function App() {
   const [open, setOpen] = createSignal(false)
+  const [pendingSteamOwnedNotice, setPendingSteamOwnedNotice] = createSignal(false)
+  const [pendingSteamOwnedNoticeUsedCache, setPendingSteamOwnedNoticeUsedCache] =
+    createSignal(false)
+  const [pendingSteamAccountNotice, setPendingSteamAccountNotice] = createSignal(false)
 
-  const [products, { refetch: refresh }] = createResource<Product[], boolean>(async (_, info) => {
-    console.debug('Loading products...')
-    const orders = loadOrders()
-    const owned = await loadOwnedApps(info.refetching)
+  const refreshAfterSteamPageOpen = () => {
+    window.setTimeout(() => refreshProducts(), 3000)
+  }
 
-    console.debug('Loaded', orders.length, 'orders,', owned.length, 'owned apps')
-    return getProducts(orders, owned)
-  })
+  const showOwnedNotice = (usedCache: boolean) => {
+    showSteamOwnedNotice(usedCache, refreshAfterSteamPageOpen)
+  }
+
+  const showAccountNotice = () => {
+    showSteamAccountNotice(refreshAfterSteamPageOpen)
+  }
+
+  const toggleOpen = () => {
+    const next = !open()
+    setOpen(next)
+
+    if (next && pendingSteamAccountNotice()) {
+      setPendingSteamAccountNotice(false)
+      showAccountNotice()
+    }
+
+    if (next && pendingSteamOwnedNotice()) {
+      setPendingSteamOwnedNotice(false)
+      showOwnedNotice(pendingSteamOwnedNoticeUsedCache())
+    }
+  }
+
+  const [products, { refetch: refreshProducts }] = createResource<Product[], boolean>(
+    async (_, info) => {
+      console.debug('Loading products...')
+      const orders = loadOrders()
+      const owned = await loadOwnedApps(info.refetching)
+
+      if (owned.accountLoadFailed) {
+        if (open()) {
+          showAccountNotice()
+        } else {
+          setPendingSteamAccountNotice(true)
+        }
+      } else {
+        setPendingSteamAccountNotice(false)
+        clearSteamAccountNotice()
+      }
+
+      if (owned.liveLoadFailed) {
+        if (open()) {
+          showOwnedNotice(owned.usedCache)
+        } else {
+          setPendingSteamOwnedNotice(true)
+          setPendingSteamOwnedNoticeUsedCache(owned.usedCache)
+        }
+      } else {
+        setPendingSteamOwnedNotice(false)
+        setPendingSteamOwnedNoticeUsedCache(false)
+        clearSteamOwnedNotice()
+      }
+
+      console.debug(
+        'Loaded',
+        orders.length,
+        'orders,',
+        owned.apps?.length ?? 'unavailable',
+        'owned apps'
+      )
+      return getProducts(orders, owned.apps)
+    }
+  )
 
   const [dt, setDt] = createSignal<Api<Product> | null>(null)
   console.debug('App loaded')
@@ -26,7 +98,7 @@ export function App() {
       <button
         type="button"
         class="js-big-button js-nav-button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={toggleOpen}
         style={{ 'margin-bottom': '10px' }}
       >
         <i class="hb hb-key"></i> Advanced Exporter
@@ -34,7 +106,7 @@ export function App() {
 
       <div classList={{ hidden: !open() }}>
         <div style={{ display: 'flex', 'justify-content': 'end', 'align-items': 'center' }}>
-          <Refresh refresh={refresh} />
+          <Refresh refresh={refreshProducts} />
         </div>
         <Show when={products()?.length} fallback={<p>Loading products...</p>}>
           <Table products={products()} setDt={setDt} />

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -39,7 +39,10 @@ export function App() {
     checkSteamAccountTimer = window.setTimeout(async () => {
       const account = await fetchSteamAccountId()
 
-      if (!account.loadFailed && account.steamId !== steamId()) {
+      if (
+        (!account.loadFailed && account.steamId !== steamId()) ||
+        (account.loggedOut && steamId())
+      ) {
         clearSteamNotices()
         refreshProducts()
       }
@@ -57,6 +60,11 @@ export function App() {
   const toggleOpen = () => {
     const next = !open()
     setOpen(next)
+
+    if (next && (pendingSteamAccountNotice() || pendingSteamOwnedNotice())) {
+      refreshProducts()
+      return
+    }
 
     if (next) {
       checkSteamAccountChanged()

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -1,6 +1,5 @@
 import { createSignal, type Accessor } from 'solid-js'
-import { redeem, type Product } from '../util'
-import { showToast } from '@violentmonkey/ui'
+import { redeem, showFlashToast, type Product } from '../util'
 // @ts-expect-error missing types
 import styles from '../style.module.css'
 import type { Api } from 'datatables.net-dt'
@@ -112,7 +111,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product>> }) {
         break
     }
     setExporting(false)
-    showToast('Exported to clipboard')
+    showFlashToast('Exported to clipboard')
   }
 
   return (

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -301,7 +301,7 @@ export function Table({
               render: (data, type) => displayYesNoBadge(data, type, styles.warning_badge),
             },
             {
-              title: 'Owned',
+              title: `Owned <span class="${styles.header_note}" title="Relies on the Steam app ID returned by Humble's API and may be inaccurate for package/sub keys.">ⓘ</span>`,
               data: 'owned',
               type: 'string-utf8',
               render: displayOwned,
@@ -311,7 +311,7 @@ export function Table({
               // ---------------------------------------------------------------
               // "Redeemed" column — Steam Support app-level data
               // ---------------------------------------------------------------
-              title: 'Redeemed',
+              title: `Redeemed <span class="${styles.header_note}" title="Uses Steam Support app ID data and may be inaccurate for package/sub keys.">ⓘ</span>`,
               data: null,
               type: 'date',
               className: 'dt-right',

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -275,7 +275,7 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
               },
             },
             {
-              title: 'Gift',
+              title: 'Format',
               data: 'type',
               type: 'string-utf8',
               render: displayDash,

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -301,7 +301,7 @@ export function Table({
               render: (data, type) => displayYesNoBadge(data, type, styles.warning_badge),
             },
             {
-              title: `Owned <span class="${styles.header_note}" title="Relies on the Steam app ID returned by Humble's API and may be inaccurate for package/sub keys.">ⓘ</span>`,
+              title: `Owned <span class="${styles.header_note}" title="Relies on the Steam app ID returned by Humble's API and may be inaccurate for package/sub keys."></span>`,
               data: 'owned',
               type: 'string-utf8',
               render: displayOwned,
@@ -311,7 +311,7 @@ export function Table({
               // ---------------------------------------------------------------
               // "Redeemed" column — Steam Support app-level data
               // ---------------------------------------------------------------
-              title: `Redeemed <span class="${styles.header_note}" title="Uses Steam Support app ID data and may be inaccurate for package/sub keys.">ⓘ</span>`,
+              title: `Redeemed <span class="${styles.header_note}" title="Uses Steam Support app ID data and may be inaccurate for package/sub keys."></span>`,
               data: null,
               type: 'date',
               className: 'dt-right',

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -4,6 +4,8 @@ import {
   redeem,
   fetchRedeemedDate,
   setRedeemedDate,
+  showErrorToast,
+  showFlashToast,
   showSteamSupportNotice,
   type Product,
 } from '../util'
@@ -11,7 +13,6 @@ import DataTable, { type Api } from 'datatables.net-dt'
 import { hm } from '@violentmonkey/dom'
 // @ts-expect-error missing types
 import styles from '../style.module.css'
-import { showToast } from '@violentmonkey/ui'
 
 export function Table({ products, setDt }: { products: Product[]; setDt: Setter<Api<Product>> }) {
   let tableRef!: HTMLTableElement
@@ -239,7 +240,7 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                   'i',
                   {
                     class: `hb hb-key hb-${data}`,
-                    onclick: () => showToast(JSON.stringify(row, null, 2)),
+                    onclick: () => showFlashToast(JSON.stringify(row, null, 2)),
                   },
                   hm('span', { class: 'hidden', innerText: String(data) })
                 )
@@ -371,7 +372,7 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                         }
                       } catch (err) {
                         showSteamSupportNotice(row.steam_app_id!)
-                        showToast(err instanceof Error ? err.message : 'Failed to fetch')
+                        showErrorToast(err, 'Failed to fetch')
                         target.disabled = false
                         target.innerHTML = '<i class="hb hb-clock"></i>'
                       }
@@ -417,7 +418,7 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                         type: 'button',
                         onclick: () => {
                           navigator.clipboard.writeText(row.redeemed_key_val)
-                          showToast('Copied to clipboard')
+                          showFlashToast('Copied to clipboard')
                         },
                       },
                       hm('i', { class: 'hb hb-key hb-clipboard' })
@@ -464,9 +465,9 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                           try {
                             const key = await redeem(row)
                             await navigator.clipboard.writeText(key)
-                            showToast('Key copied to clipboard')
+                            showFlashToast('Key copied to clipboard')
                           } catch (error) {
-                            showToast(error instanceof Error ? error.message : String(error))
+                            showErrorToast(error)
                           }
                         },
                       },
@@ -481,9 +482,9 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                           try {
                             const link = await redeem(row, true)
                             await navigator.clipboard.writeText(link)
-                            showToast('Link copied to clipboard')
+                            showFlashToast('Link copied to clipboard')
                           } catch (error) {
-                            showToast(error instanceof Error ? error.message : String(error))
+                            showErrorToast(error)
                           }
                         },
                       },

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -209,6 +209,11 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
     setDt(
       () =>
         (dt = new DataTable<Product>(tableRef, {
+          pageLength: 10,
+          lengthMenu: [
+            [10, 25, 50, 100, 500, 1000, 5000, -1],
+            [10, 25, 50, 100, 500, '1,000', '5,000', 'All'],
+          ],
           columnDefs: [
             {
               targets: [7, 9],
@@ -356,7 +361,9 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                             }
                           }
 
-                          dt.rows().invalidate('data').draw('page')
+                          dt.rows((_idx, product) => product.steam_app_id === appId)
+                            .invalidate('data')
+                            .draw('page')
                         } else {
                           showSteamSupportNotice(row.steam_app_id!)
                           target.disabled = false

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,5 +1,12 @@
 import { onCleanup, onMount, type Setter } from 'solid-js'
-import { redeem, fetchRedeemedDate, setRedeemedDate, type Product } from '../util'
+import {
+  clearSteamSupportNotice,
+  redeem,
+  fetchRedeemedDate,
+  setRedeemedDate,
+  showSteamSupportNotice,
+  type Product,
+} from '../util'
 import DataTable, { type Api } from 'datatables.net-dt'
 import { hm } from '@violentmonkey/dom'
 // @ts-expect-error missing types
@@ -36,6 +43,31 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
         class: `${styles.yes_no_badge} ${value === 'Yes' ? styles.yes_badge : noClassName}`,
         innerText: value,
       }) as unknown as string
+    }
+
+    const displayTooltipDash = (title: string, className?: string): string =>
+      hm('span', {
+        class: className,
+        title,
+        innerText: '-',
+      }) as unknown as string
+
+    const displayOwned = (data: unknown, type: string, row: Product): string => {
+      if (data) return displayYesNoBadge(data, type)
+      if (type !== 'display') return ''
+
+      if (row.key_type !== 'steam') {
+        return displayTooltipDash('Ownership detection is only available for Steam keys.')
+      }
+
+      if (!row.steam_app_id) {
+        return displayTooltipDash(
+          "Humble's API returned an empty Steam app ID.",
+          `${styles.yes_no_badge} ${styles.info_badge}`
+        )
+      }
+
+      return displayTooltipDash('Steam ownership data could not be loaded.')
     }
 
     const displayDateOnly = (iso: string): string =>
@@ -258,7 +290,7 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
               title: 'Owned',
               data: 'owned',
               type: 'string-utf8',
-              render: displayYesNoBadge,
+              render: displayOwned,
             },
             { title: 'Purchased', data: 'created', type: 'date' },
             {
@@ -316,6 +348,7 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                           const appId = row.steam_app_id!
 
                           setRedeemedDate(appId, result)
+                          clearSteamSupportNotice(appId)
 
                           for (const product of products) {
                             if (product.steam_app_id === appId) {
@@ -325,11 +358,12 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
 
                           dt.rows().invalidate('data').draw('page')
                         } else {
-                          showToast('No redeemed date found on Steam Support page')
+                          showSteamSupportNotice(row.steam_app_id!)
                           target.disabled = false
                           target.innerHTML = '<i class="hb hb-clock"></i>'
                         }
                       } catch (err) {
+                        showSteamSupportNotice(row.steam_app_id!)
                         showToast(err instanceof Error ? err.message : 'Failed to fetch')
                         target.disabled = false
                         target.innerHTML = '<i class="hb hb-clock"></i>'
@@ -524,7 +558,7 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
     const warnings: WarningRule[] = [
       {
         element: makeWarning(
-          '⚠️ "Owned" column: Keys containing multiple app IDs/content can incorrectly appear owned because only one app ID is returned by Humble\'s API. This column may also contain many null values.'
+          '⚠️ "Owned" column: Keys containing multiple app IDs/content can incorrectly appear owned because Humble\'s API does not return package IDs. This column shows a dash when ownership detection is not supported, Humble\'s API does not provide a Steam app ID, or Steam ownership data cannot be loaded.'
         ),
         show: (selectedColumns) => selectedColumns.includes('Owned'),
       },

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,4 +1,4 @@
-import { onCleanup, onMount, type Setter } from 'solid-js'
+import { onCleanup, onMount, type Accessor, type Setter } from 'solid-js'
 import {
   clearSteamSupportNotice,
   redeem,
@@ -14,7 +14,15 @@ import { hm } from '@violentmonkey/dom'
 // @ts-expect-error missing types
 import styles from '../style.module.css'
 
-export function Table({ products, setDt }: { products: Product[]; setDt: Setter<Api<Product>> }) {
+export function Table({
+  products,
+  steamId,
+  setDt,
+}: {
+  products: Product[]
+  steamId: Accessor<string | null>
+  setDt: Setter<Api<Product>>
+}) {
   let tableRef!: HTMLTableElement
 
   onMount(() => {
@@ -314,13 +322,16 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                   return row.redeemed_date?.iso ?? ''
                 }
 
+                // ── Not owned on this Steam account — nothing to show ───────────────────
+                if (!row.steam_app_id || row.owned !== 'Yes') return '-'
+
                 // ── Already fetched ─────────────────────────────────────────
                 if (row.redeemed_date) {
                   const { label, iso } = row.redeemed_date
                   return hm(
                     'a',
                     {
-                      href: steamSupportUrl(row.steam_app_id!),
+                      href: steamSupportUrl(row.steam_app_id),
                       target: '_blank',
                       title: 'Open Steam Support page',
                     },
@@ -333,9 +344,6 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                     ]
                   ) as unknown as string
                 }
-
-                // ── Not owned on this Steam account — nothing to show ───────────────────
-                if (!row.steam_app_id || row.owned !== 'Yes') return '-'
 
                 // ── Not yet fetched: show a fetch button ────────────────────────────────
                 const fetchBtn = hm(
@@ -353,7 +361,7 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
                         if (result) {
                           const appId = row.steam_app_id!
 
-                          setRedeemedDate(appId, result)
+                          setRedeemedDate(appId, result, steamId())
                           clearSteamSupportNotice(appId)
 
                           for (const product of products) {
@@ -610,6 +618,8 @@ export function Table({ products, setDt }: { products: Product[]; setDt: Setter<
       searchBuilderRoot?.removeEventListener('change', refreshWarnings)
       observer?.disconnect()
       for (const warning of warnings) warning.element.remove()
+
+      dt.destroy()
     })
   })
   console.debug('Table Loaded')

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -66,8 +66,13 @@ tr.expired {
 }
 
 .no_badge {
-  background-color: #e2e3e5;
-  color: #41464b;
+  background-color: #cfd4da;
+  color: #212529;
+}
+
+.info_badge {
+  background-color: #b8d4ec;
+  color: #0f3048;
 }
 
 .warning_badge {

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -10,6 +10,15 @@ tr.expired {
   white-space: nowrap;
 }
 
+.header_note {
+  margin-left: 3px;
+  color: #2f6f9f;
+  font-size: 12px;
+  font-weight: 700;
+  vertical-align: 1px;
+  cursor: help;
+}
+
 .select {
   padding: 5px 30px 5px 10px;
   border: 1px solid #ccc;

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -19,6 +19,10 @@ tr.expired {
   cursor: help;
 }
 
+.header_note::after {
+  content: 'ⓘ';
+}
+
 .select {
   padding: 5px 30px 5px 10px;
   border: 1px solid #ccc;

--- a/src/styles.css
+++ b/src/styles.css
@@ -19,6 +19,24 @@
   margin-bottom: 15px;
 }
 
+#hb_extractor-container .dt-container {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+#hb_extractor-table {
+  width: 100% !important;
+}
+
+#hb_extractor-table thead th {
+  white-space: nowrap;
+}
+
+#hb_extractor-table tbody td:nth-child(2) {
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
 #hb_extractor-container details {
   display: unset;
   width: 100%;

--- a/src/styles.css
+++ b/src/styles.css
@@ -119,20 +119,20 @@
   z-index: 999999;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  max-width: 320px;
+  gap: 10px;
+  max-width: 380px;
 }
 
 .hb_extractor-notice {
   position: relative;
-  padding: 8px 28px 8px 10px;
+  padding: 12px 36px 12px 14px;
   background: #fff3cd;
   color: #664d03;
   border: 1px solid #ffecb5;
-  border-radius: 4px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  font-size: 12px;
-  line-height: 1.35;
+  border-radius: 5px;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.16);
+  font-size: 13.5px;
+  line-height: 1.45;
 }
 
 .hb_extractor-notice p {

--- a/src/styles.css
+++ b/src/styles.css
@@ -36,3 +36,54 @@
   background: #fff !important;
   color: #000 !important;
 }
+
+#hb_extractor-notices {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  z-index: 999999;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 320px;
+}
+
+.hb_extractor-notice {
+  position: relative;
+  padding: 8px 28px 8px 10px;
+  background: #fff3cd;
+  color: #664d03;
+  border: 1px solid #ffecb5;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.hb_extractor-notice p {
+  margin: 3px 0 5px;
+}
+
+.hb_extractor-notice a {
+  color: #664d03;
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.hb_extractor-notice-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.hb_extractor-notice-close {
+  position: absolute;
+  top: 3px;
+  right: 6px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #664d03;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -37,6 +37,63 @@
   overflow-wrap: anywhere;
 }
 
+#hb_extractor-flash-toast {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  z-index: 999999;
+  max-width: 440px;
+  max-height: 55vh;
+  overflow: auto;
+  padding: 12px 16px;
+  border: 1px solid;
+  border-radius: 6px;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.28);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.4;
+  text-align: center;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  transform: translate(-50%, -50%);
+}
+
+.hb_extractor-flash-toast_default {
+  background: #e7f1ff;
+  color: #084298;
+  border-color: #b6d4fe;
+}
+
+.hb_extractor-flash-toast_error {
+  background: #f8d7da;
+  color: #842029;
+  border-color: #f5c2c7;
+}
+
+@keyframes hb_extractor-flash-toast-flash {
+  0% {
+    opacity: 0.35;
+    transform: translate(-50%, calc(-50% + 8px)) scale(0.96);
+    filter: brightness(1.15);
+  }
+
+  35% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1.03);
+    filter: brightness(1.15);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+    filter: none;
+  }
+}
+
+.hb_extractor-flash-toast_flash {
+  animation: hb_extractor-flash-toast-flash 700ms ease-out;
+}
+
 #hb_extractor-container details {
   display: unset;
   width: 100%;

--- a/src/util.ts
+++ b/src/util.ts
@@ -397,6 +397,7 @@ const requestSteam = (
 type SteamAccountIdResult = {
   steamId: string | null
   loadFailed: boolean
+  loggedOut: boolean
 }
 
 export const fetchSteamAccountId = async (): Promise<SteamAccountIdResult> =>
@@ -410,6 +411,7 @@ export const fetchSteamAccountId = async (): Promise<SteamAccountIdResult> =>
         return {
           steamId,
           loadFailed: false,
+          loggedOut: false,
         }
       }
 
@@ -417,12 +419,14 @@ export const fetchSteamAccountId = async (): Promise<SteamAccountIdResult> =>
         return {
           steamId: (STEAM_ID64_BASE + BigInt(accountId)).toString(),
           loadFailed: false,
+          loggedOut: false,
         }
       }
 
       return {
         steamId: null,
         loadFailed: true,
+        loggedOut: true,
       }
     })
     .catch((err) => {
@@ -430,6 +434,7 @@ export const fetchSteamAccountId = async (): Promise<SteamAccountIdResult> =>
       return {
         steamId: null,
         loadFailed: true,
+        loggedOut: false,
       }
     })
 
@@ -879,7 +884,11 @@ export const loadOwnedApps = async (refresh: boolean = false): Promise<OwnedApps
 
   ownedAppsLiveLoadFailed = true
 
-  if (!refresh && cache && (!steamId || steamId === cache.steamId)) {
+  if (
+    !refresh &&
+    cache &&
+    (steamId === cache.steamId || (!steamId && steamAccount.loadFailed && !steamAccount.loggedOut))
+  ) {
     ownedApps = cache.apps
     ownedAppsLoaded = true
     ownedAppsUsedCache = true

--- a/src/util.ts
+++ b/src/util.ts
@@ -287,8 +287,12 @@ export const loadOrders = () =>
     .map((key) => JSON.parse(LZString.decompressFromUTF16(localStorage.getItem(key))) as Order)
     .filter((order) => order?.tpkd_dict?.all_tpks?.length)
 
-export const getProducts = (orders: Order[], ownedApps: number[] | null): Product[] => {
-  const redeemedMap = loadRedeemedDatesMap()
+export const getProducts = (
+  orders: Order[],
+  ownedApps: number[] | null,
+  steamId: string | null
+): Product[] => {
+  const redeemedMap = loadRedeemedDatesMap(steamId)
 
   return orders.flatMap((order) =>
     order.tpkd_dict.all_tpks.map((product) => {
@@ -300,6 +304,13 @@ export const getProducts = (orders: Order[], ownedApps: number[] | null): Produc
           : undefined
       const expiryMs = expiry ? Date.parse(expiry) : NaN
       const isExpired = product.is_expired || (!Number.isNaN(expiryMs) && expiryMs < Date.now())
+      const owned: Product['owned'] = steamAppId
+        ? ownedApps === null
+          ? ''
+          : ownedApps.includes(steamAppId)
+            ? 'Yes'
+            : 'No'
+        : ''
 
       return {
         machine_name: product.machine_name || '',
@@ -316,14 +327,11 @@ export const getProducts = (orders: Order[], ownedApps: number[] | null): Produc
         steam_app_id: steamAppId,
         created,
         keyindex: product.keyindex,
-        owned: steamAppId
-          ? ownedApps === null
-            ? ''
-            : ownedApps.includes(steamAppId)
-              ? 'Yes'
-              : 'No'
-          : '',
-        redeemed_date: steamAppId ? (redeemedMap[String(steamAppId)] ?? undefined) : undefined,
+        owned,
+        redeemed_date:
+          steamAppId && owned === 'Yes'
+            ? (redeemedMap[String(steamAppId)] ?? undefined)
+            : undefined,
       }
     })
   )
@@ -391,7 +399,7 @@ type SteamAccountIdResult = {
   loadFailed: boolean
 }
 
-const fetchSteamAccountId = async (): Promise<SteamAccountIdResult> =>
+export const fetchSteamAccountId = async (): Promise<SteamAccountIdResult> =>
   requestSteam(`https://store.steampowered.com/account/?_=${Date.now()}`)
     .then((res) => {
       const html = res.responseText ?? ''
@@ -595,6 +603,12 @@ const clearSteamNotice = (id: string): void => {
   document.getElementById(id)?.remove()
 }
 
+export const clearSteamNotices = (): void => {
+  document
+    .querySelectorAll<HTMLElement>('[id^="hb_extractor-notice-steam-"]')
+    .forEach((notice) => notice.remove())
+}
+
 export const showSteamOwnedNotice = (usedCache: boolean, onOpen?: () => void): void => {
   showSteamNotice(
     'hb_extractor-notice-steam-owned-apps',
@@ -660,23 +674,59 @@ export const clearSteamSupportNotice = (appId: number): void => {
 // Redeemed date — Steam Support app-level data
 // ---------------------------------------------------------------------------
 
-const REDEEMED_DATES_KEY = 'hb-key-exporter:redeemed-dates'
+const REDEEMED_DATES_LEGACY_KEY = 'hb-key-exporter:redeemed-dates'
+const REDEEMED_DATES_KEY_PREFIX = 'hb-key-exporter:redeemed-dates:v2'
 
-const loadRedeemedDatesMap = (): Record<string, RedeemedDate> => {
+let redeemedDatesLegacyCacheCleared = false
+
+const clearLegacyRedeemedDatesCache = (): void => {
+  if (redeemedDatesLegacyCacheCleared) return
+
+  redeemedDatesLegacyCacheCleared = true
+
   try {
-    const data = localStorage.getItem(REDEEMED_DATES_KEY)
+    localStorage.removeItem(REDEEMED_DATES_LEGACY_KEY)
+
+    for (const key of Object.keys(localStorage)) {
+      if (/^hb-key-exporter:redeemed-dates:\d+$/.test(key)) {
+        localStorage.removeItem(key)
+      }
+    }
+  } catch (e) {
+    console.error('Failed to clear legacy redeemed dates cache:', e)
+  }
+}
+
+const getRedeemedDatesKey = (steamId: string): string => `${REDEEMED_DATES_KEY_PREFIX}:${steamId}`
+
+const loadRedeemedDatesMap = (steamId: string | null): Record<string, RedeemedDate> => {
+  clearLegacyRedeemedDatesCache()
+
+  if (!steamId) return {}
+
+  try {
+    const data = localStorage.getItem(getRedeemedDatesKey(steamId))
     return data ? JSON.parse(data) : {}
   } catch {
     return {}
   }
 }
 
-export const setRedeemedDate = (appId: number, entry: RedeemedDate): void => {
+export const setRedeemedDate = (
+  appId: number,
+  entry: RedeemedDate,
+  steamId: string | null
+): void => {
+  clearLegacyRedeemedDatesCache()
+
+  if (!steamId) return
+
   try {
-    const data = localStorage.getItem(REDEEMED_DATES_KEY)
+    const key = getRedeemedDatesKey(steamId)
+    const data = localStorage.getItem(key)
     const map: Record<string, RedeemedDate> = data ? JSON.parse(data) : {}
     map[String(appId)] = entry
-    localStorage.setItem(REDEEMED_DATES_KEY, JSON.stringify(map))
+    localStorage.setItem(key, JSON.stringify(map))
   } catch (e) {
     console.error('Failed to store redeemed date:', e)
   }
@@ -772,6 +822,7 @@ export type OwnedAppsResult = {
   liveLoadFailed: boolean
   usedCache: boolean
   accountLoadFailed: boolean
+  steamId: string | null
 }
 
 let ownedApps: number[] | null = null
@@ -779,6 +830,7 @@ let ownedAppsLoaded = false
 let ownedAppsLiveLoadFailed = false
 let ownedAppsUsedCache = false
 let steamAccountLoadFailed = false
+let currentSteamId: string | null = null
 
 export const loadOwnedApps = async (refresh: boolean = false): Promise<OwnedAppsResult> => {
   if (!refresh && ownedAppsLoaded) {
@@ -787,6 +839,7 @@ export const loadOwnedApps = async (refresh: boolean = false): Promise<OwnedApps
       liveLoadFailed: ownedAppsLiveLoadFailed,
       usedCache: ownedAppsUsedCache,
       accountLoadFailed: steamAccountLoadFailed,
+      steamId: currentSteamId,
     }
   }
 
@@ -796,6 +849,7 @@ export const loadOwnedApps = async (refresh: boolean = false): Promise<OwnedApps
   console.debug('Steam account ID:', steamAccount ?? 'unavailable')
   console.debug('Steam steam ID:', steamId ?? 'unavailable')
   steamAccountLoadFailed = steamAccount.loadFailed
+  currentSteamId = steamId
 
   if (steamId && cache?.steamId && steamId !== cache.steamId) {
     clearOwnedAppsCache()
@@ -819,6 +873,7 @@ export const loadOwnedApps = async (refresh: boolean = false): Promise<OwnedApps
       liveLoadFailed: false,
       usedCache: false,
       accountLoadFailed: steamAccountLoadFailed,
+      steamId,
     }
   }
 
@@ -836,6 +891,7 @@ export const loadOwnedApps = async (refresh: boolean = false): Promise<OwnedApps
       liveLoadFailed: true,
       usedCache: true,
       accountLoadFailed: steamAccountLoadFailed,
+      steamId,
     }
   }
 
@@ -847,5 +903,6 @@ export const loadOwnedApps = async (refresh: boolean = false): Promise<OwnedApps
     liveLoadFailed: true,
     usedCache: false,
     accountLoadFailed: steamAccountLoadFailed,
+    steamId,
   }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -479,6 +479,53 @@ const fetchOwnedApps = async (): Promise<number[] | null> =>
       return null
     })
 
+type FlashToastType = 'default' | 'error'
+
+const getFlashToastDuration = (message: string): number => {
+  const trimmed = message.trim()
+  const words = trimmed ? trimmed.split(/\s+/).length : 0
+
+  return Math.min(8000, Math.max(2500, 1500 + words * 250 + trimmed.length * 8))
+}
+
+let flashToastEl: HTMLElement | null = null
+let flashToastTimer: number | undefined
+
+export const showFlashToast = (message: string, type: FlashToastType = 'default'): void => {
+  if (!flashToastEl) {
+    flashToastEl = document.createElement('div')
+    flashToastEl.id = 'hb_extractor-flash-toast'
+    document.body.append(flashToastEl)
+  }
+
+  flashToastEl.textContent = message
+  flashToastEl.hidden = false
+  flashToastEl.className = `hb_extractor-flash-toast hb_extractor-flash-toast_${type}`
+  flashToastEl.setAttribute('role', type === 'error' ? 'alert' : 'status')
+
+  void flashToastEl.offsetWidth
+  flashToastEl.classList.add('hb_extractor-flash-toast_flash')
+
+  if (flashToastTimer !== undefined) {
+    window.clearTimeout(flashToastTimer)
+  }
+
+  flashToastTimer = window.setTimeout(() => {
+    if (flashToastEl) {
+      flashToastEl.hidden = true
+    }
+
+    flashToastTimer = undefined
+  }, getFlashToastDuration(message))
+}
+
+export const showErrorToast = (error: unknown, fallback = 'Failed'): void => {
+  const message =
+    error instanceof Error ? error.message || fallback : error == null ? fallback : String(error)
+
+  showFlashToast(message, 'error')
+}
+
 type SteamNoticeLink = {
   text: string
   href: string

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,7 +18,7 @@ export interface Order {
       key_type: string
       keyindex: number
       redeemed_key_val?: string
-      steam_app_id?: number
+      steam_app_id?: number | null
       sold_out?: boolean
       direct_redeem?: boolean
       exclusive_countries?: string[]
@@ -287,13 +287,17 @@ export const loadOrders = () =>
     .map((key) => JSON.parse(LZString.decompressFromUTF16(localStorage.getItem(key))) as Order)
     .filter((order) => order?.tpkd_dict?.all_tpks?.length)
 
-export const getProducts = (orders: Order[], ownedApps: number[]): Product[] => {
+export const getProducts = (orders: Order[], ownedApps: number[] | null): Product[] => {
   const redeemedMap = loadRedeemedDatesMap()
 
   return orders.flatMap((order) =>
     order.tpkd_dict.all_tpks.map((product) => {
       const expiry = resolveExpiryDate(product)
       const created = order.created ? normalizeHumbleDateTime(order.created) : ''
+      const steamAppId =
+        typeof product.steam_app_id === 'number' && product.steam_app_id > 0
+          ? product.steam_app_id
+          : undefined
       const expiryMs = expiry ? Date.parse(expiry) : NaN
       const isExpired = product.is_expired || (!Number.isNaN(expiryMs) && expiryMs < Date.now())
 
@@ -309,17 +313,17 @@ export const getProducts = (orders: Order[], ownedApps: number[]): Product[] => 
         is_gift: product.is_gift || false,
         is_expired: isExpired,
         expiry_date: expiry,
-        steam_app_id: product.steam_app_id,
+        steam_app_id: steamAppId,
         created,
         keyindex: product.keyindex,
-        owned: product.steam_app_id
-          ? ownedApps.includes(product.steam_app_id)
-            ? 'Yes'
-            : 'No'
+        owned: steamAppId
+          ? ownedApps === null
+            ? ''
+            : ownedApps.includes(steamAppId)
+              ? 'Yes'
+              : 'No'
           : '',
-        redeemed_date: product.steam_app_id
-          ? (redeemedMap[String(product.steam_app_id)] ?? undefined)
-          : undefined,
+        redeemed_date: steamAppId ? (redeemedMap[String(steamAppId)] ?? undefined) : undefined,
       }
     })
   )
@@ -350,40 +354,260 @@ type SteamUserData = {
   rgOwnedApps?: number[]
 }
 
-const fetchOwnedApps = async (): Promise<number[]> =>
-  new Promise<VMScriptResponseObject<unknown>>((resolve, reject) =>
+type OwnedAppsCache = {
+  steamId: string
+  apps: number[]
+  fetchedAt: string
+}
+
+const OWNED_APPS_KEY = 'hb-key-exporter:owned-apps'
+const OWNED_APPS_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000
+const STEAM_ID64_BASE = 76561197960265728n
+
+const requestSteam = (
+  url: string,
+  responseType?: 'json'
+): Promise<VMScriptResponseObject<unknown>> =>
+  new Promise((resolve, reject) =>
     GM_xmlhttpRequest({
-      url: `https://store.steampowered.com/dynamicstore/userdata?_=${Date.now()}`, // Blank query to force a cache reload every time
+      url,
       method: 'GET',
       timeout: 5000,
-      responseType: 'json',
+      responseType,
       onload: (res) => {
         if (res.status !== 200) {
-          console.error(`Steam owned apps request failed with HTTP ${res.status}`)
           reject(new Error(`HTTP ${res.status}`))
           return
         }
         resolve(res)
       },
-      onerror: (err) => {
-        console.error('Steam owned apps request error:', err)
-        reject(new Error('Steam owned apps request failed'))
-      },
-      ontimeout: () => {
-        console.error('Steam owned apps request timed out')
-        reject(new Error('Steam owned apps request timed out'))
-      },
+      onerror: () => reject(new Error('Steam request failed')),
+      ontimeout: () => reject(new Error('Steam request timed out')),
     })
   )
-    .then((data) => {
-      const apps = (data.response as SteamUserData | null)?.rgOwnedApps ?? []
+
+type SteamAccountIdResult = {
+  steamId: string | null
+  loadFailed: boolean
+}
+
+const fetchSteamAccountId = async (): Promise<SteamAccountIdResult> =>
+  requestSteam(`https://store.steampowered.com/account/?_=${Date.now()}`)
+    .then((res) => {
+      const html = res.responseText ?? ''
+      const steamId = html.match(/\bg_steamID\s*=\s*["']?(\d+)["']?/)?.[1]
+      const accountId = html.match(/\bg_AccountID\s*=\s*(\d+)/)?.[1]
+
+      if (steamId && steamId !== '0') {
+        return {
+          steamId,
+          loadFailed: false,
+        }
+      }
+
+      if (accountId && accountId !== '0') {
+        return {
+          steamId: (STEAM_ID64_BASE + BigInt(accountId)).toString(),
+          loadFailed: false,
+        }
+      }
+
+      return {
+        steamId: null,
+        loadFailed: true,
+      }
+    })
+    .catch((err) => {
+      console.warn('Failed to detect Steam account:', err)
+      return {
+        steamId: null,
+        loadFailed: true,
+      }
+    })
+
+const loadOwnedAppsCache = (): OwnedAppsCache | null => {
+  try {
+    const data = localStorage.getItem(OWNED_APPS_KEY)
+    if (!data) return null
+
+    const cache = JSON.parse(data) as OwnedAppsCache
+    if (!cache.steamId || !Array.isArray(cache.apps)) return null
+
+    const age = Date.now() - Date.parse(cache.fetchedAt)
+    if (!Number.isFinite(age) || age > OWNED_APPS_CACHE_MAX_AGE_MS) return null
+
+    return cache
+  } catch {
+    return null
+  }
+}
+
+const saveOwnedAppsCache = (steamId: string, apps: number[]): void => {
+  try {
+    localStorage.setItem(
+      OWNED_APPS_KEY,
+      JSON.stringify({
+        steamId,
+        apps,
+        fetchedAt: new Date().toISOString(),
+      } satisfies OwnedAppsCache)
+    )
+  } catch (e) {
+    console.error('Failed to store Steam owned apps:', e)
+  }
+}
+
+const clearOwnedAppsCache = (): void => {
+  localStorage.removeItem(OWNED_APPS_KEY)
+}
+
+const fetchOwnedApps = async (): Promise<number[] | null> =>
+  requestSteam(`https://store.steampowered.com/dynamicstore/userdata?_=${Date.now()}`, 'json')
+    .then((res) => {
+      const apps = (res.response as SteamUserData | null)?.rgOwnedApps
+
+      if (!Array.isArray(apps) || apps.length === 0) {
+        console.warn('Steam owned apps unavailable or empty')
+        return null
+      }
+
       console.debug(`Steam owned apps fetched: ${apps.length}`)
       return apps
     })
     .catch((err) => {
       console.error('Failed to load Steam owned apps:', err)
-      return []
+      return null
     })
+
+type SteamNoticeLink = {
+  text: string
+  href: string
+  onClick?: () => void
+}
+
+const ensureNoticeRoot = (): HTMLElement => {
+  let root = document.getElementById('hb_extractor-notices')
+
+  if (!root) {
+    root = document.createElement('div')
+    root.id = 'hb_extractor-notices'
+    document.body.append(root)
+  }
+
+  return root
+}
+
+const showSteamNotice = (
+  id: string,
+  title: string,
+  message: string | string[],
+  links: SteamNoticeLink[]
+): void => {
+  if (document.getElementById(id)) return
+
+  const notice = document.createElement('div')
+  notice.id = id
+  notice.className = 'hb_extractor-notice'
+
+  const heading = document.createElement('strong')
+  heading.textContent = title
+
+  const close = document.createElement('button')
+  close.type = 'button'
+  close.className = 'hb_extractor-notice-close'
+  close.title = 'Dismiss'
+  close.textContent = '×'
+  close.addEventListener('click', () => notice.remove())
+
+  const body = document.createElement('p')
+  const messageLines = Array.isArray(message) ? message : [message]
+
+  for (const [index, line] of messageLines.entries()) {
+    if (index > 0) body.append(document.createElement('br'))
+    body.append(line)
+  }
+
+  const actions = document.createElement('div')
+  actions.className = 'hb_extractor-notice-actions'
+
+  for (const link of links) {
+    const a = document.createElement('a')
+    a.href = link.href
+    a.target = '_blank'
+    a.rel = 'noopener noreferrer'
+    a.textContent = link.text
+    if (link.onClick) a.addEventListener('click', link.onClick)
+    actions.append(a)
+  }
+
+  notice.append(heading, close, body, actions)
+  ensureNoticeRoot().append(notice)
+}
+
+const clearSteamNotice = (id: string): void => {
+  document.getElementById(id)?.remove()
+}
+
+export const showSteamOwnedNotice = (usedCache: boolean, onOpen?: () => void): void => {
+  showSteamNotice(
+    'hb_extractor-notice-steam-owned-apps',
+    'Steam games could not be loaded',
+    usedCache
+      ? ['Open Steam data, then refresh.', 'Using cached Steam games from a previous load.']
+      : ['Open Steam data, then refresh.', 'No cached Steam games are available.'],
+    [
+      {
+        text: 'Open Steam data',
+        href: 'https://store.steampowered.com/dynamicstore/userdata/',
+        onClick: onOpen,
+      },
+    ]
+  )
+}
+
+export const clearSteamOwnedNotice = (): void => {
+  clearSteamNotice('hb_extractor-notice-steam-owned-apps')
+}
+
+export const showSteamAccountNotice = (onOpen?: () => void): void => {
+  showSteamNotice(
+    'hb_extractor-notice-steam-account',
+    'Steam account could not be checked',
+    [
+      'Open Steam account, then refresh.',
+      'Cache cannot be cleared automatically if you changed Steam accounts.',
+    ],
+    [
+      {
+        text: 'Open Steam account',
+        href: 'https://store.steampowered.com/account/',
+        onClick: onOpen,
+      },
+    ]
+  )
+}
+
+export const clearSteamAccountNotice = (): void => {
+  clearSteamNotice('hb_extractor-notice-steam-account')
+}
+
+export const showSteamSupportNotice = (appId: number): void => {
+  showSteamNotice(
+    `hb_extractor-notice-steam-support-${appId}`,
+    'Steam Support unavailable',
+    'Open the Support page, then retry.',
+    [
+      {
+        text: 'Open Support page',
+        href: `https://help.steampowered.com/en/wizard/HelpWithGame?appid=${appId}`,
+      },
+    ]
+  )
+}
+
+export const clearSteamSupportNotice = (appId: number): void => {
+  clearSteamNotice(`hb_extractor-notice-steam-support-${appId}`)
+}
 
 // ---------------------------------------------------------------------------
 // Redeemed date — Steam Support app-level data
@@ -496,14 +720,85 @@ export const fetchRedeemedDate = async (appId: number): Promise<RedeemedDate | n
   return null
 }
 
-let ownedApps: number[] = []
+export type OwnedAppsResult = {
+  apps: number[] | null
+  liveLoadFailed: boolean
+  usedCache: boolean
+  accountLoadFailed: boolean
+}
 
-export const loadOwnedApps = async (refresh: boolean = false): Promise<number[]> => {
-  if (!refresh && ownedApps.length) {
-    console.debug(`Steam owned apps returned from memory: ${ownedApps.length}`)
-    return ownedApps
+let ownedApps: number[] | null = null
+let ownedAppsLoaded = false
+let ownedAppsLiveLoadFailed = false
+let ownedAppsUsedCache = false
+let steamAccountLoadFailed = false
+
+export const loadOwnedApps = async (refresh: boolean = false): Promise<OwnedAppsResult> => {
+  if (!refresh && ownedAppsLoaded) {
+    return {
+      apps: ownedApps,
+      liveLoadFailed: ownedAppsLiveLoadFailed,
+      usedCache: ownedAppsUsedCache,
+      accountLoadFailed: steamAccountLoadFailed,
+    }
   }
 
-  ownedApps = await fetchOwnedApps()
-  return ownedApps
+  let cache = loadOwnedAppsCache()
+  const steamAccount = await fetchSteamAccountId()
+  const steamId = steamAccount.steamId
+  console.debug('Steam account ID:', steamAccount ?? 'unavailable')
+  console.debug('Steam steam ID:', steamId ?? 'unavailable')
+  steamAccountLoadFailed = steamAccount.loadFailed
+
+  if (steamId && cache?.steamId && steamId !== cache.steamId) {
+    clearOwnedAppsCache()
+    cache = null
+  }
+
+  const fetched = await fetchOwnedApps()
+
+  if (fetched) {
+    ownedApps = fetched
+    ownedAppsLoaded = true
+    ownedAppsLiveLoadFailed = false
+    ownedAppsUsedCache = false
+
+    if (steamId) {
+      saveOwnedAppsCache(steamId, fetched)
+    }
+
+    return {
+      apps: ownedApps,
+      liveLoadFailed: false,
+      usedCache: false,
+      accountLoadFailed: steamAccountLoadFailed,
+    }
+  }
+
+  ownedAppsLiveLoadFailed = true
+
+  if (!refresh && cache && (!steamId || steamId === cache.steamId)) {
+    ownedApps = cache.apps
+    ownedAppsLoaded = true
+    ownedAppsUsedCache = true
+    console.debug(
+      `Steam owned apps returned from cache after live load failed: ${ownedApps.length}`
+    )
+    return {
+      apps: ownedApps,
+      liveLoadFailed: true,
+      usedCache: true,
+      accountLoadFailed: steamAccountLoadFailed,
+    }
+  }
+
+  ownedApps = null
+  ownedAppsLoaded = true
+  ownedAppsUsedCache = false
+  return {
+    apps: ownedApps,
+    liveLoadFailed: true,
+    usedCache: false,
+    accountLoadFailed: steamAccountLoadFailed,
+  }
 }


### PR DESCRIPTION
## Summary

This improves Steam ownership detection failure handling by distinguishing between unsupported rows, missing Humble Steam app IDs, failed Steam ownership loads, and cached Steam ownership data.

Steam owned games are now cached per Steam account for 24 hours and reused when the live Steam owned-apps request fails. The script also checks the current Steam account so it can clear cached ownership data when the user changes Steam accounts.

When Steam data cannot be loaded, the UI now shows dismissible notices with direct links to the relevant Steam page. Opening those links triggers a delayed refresh so users can refresh their Steam session and retry without guessing what went wrong.

This also replaces the default toast calls with controlled flash notifications, adds larger table page-size options, optimizes redeemed-date redraws, and renames the `Gift` column to `Format`.

## Changes

- Cache Steam owned apps for 24 hours by Steam account.
- Detect the active Steam account from the Steam account page.
- Clear the owned-apps cache when a different Steam account is detected.
- Scope Steam redeemed-date caching by Steam account, clear stale Steam notices on account changes, and rebuild the table when refreshed data is loaded.
- Treat failed or empty Steam owned-apps responses as unavailable instead of assuming no games are owned.
  Closes #40.
- Use cached Steam owned games when the live owned-apps request fails and a matching cache is available.
- Avoid reusing cached Steam owned games when Steam is confirmed logged out.
- Add dismissible notices for Steam account, Steam owned-apps, and Steam Support loading failures.
- Defer Steam notices until the Advanced Exporter is opened, so errors do not appear while the table is collapsed.
- Refresh pending Steam state before showing deferred Steam notices when opening the Advanced Exporter.
- Add links in Steam notices to open the relevant Steam account, Steam owned-apps, or Steam Support page.
- Refresh products shortly after opening Steam account or owned-apps pages.
- Clarify `Owned` dash tooltips for non-Steam keys, missing Humble Steam app IDs, and failed Steam ownership loads.
- Add an informational blue badge for rows where Humble's API returned an empty Steam app ID.
- Adjust the unowned badge color for better contrast.
- Show a Steam Support notice when fetching a redeemed date fails or returns no date.
- Clear the Steam Support notice after a redeemed date is fetched successfully.
- Allow Humble `steam_app_id` values to be `null` and only treat positive numeric IDs as usable.
- Update the `Owned` column warning to explain the package-ID limitation and the possible dash states.
- Replace default toast calls with controlled flash notifications.
- Flash repeated toast messages again instead of leaving the same message visually unchanged.
- Auto-dismiss flash notifications based on message length.
- Add separate default and error styling for flash notifications.
- Add larger table page-size options, including 500, 1,000, 5,000, and All.
- Keep the table constrained horizontally while allowing overflow when needed.
- Improve table text wrapping for long game names.
- Only redraw matching rows after a redeemed date is fetched.
- Rename the `Gift` column to `Format`.

## Notes

`Owned` is still based on the Steam app ID returned by Humble. It can be wrong for keys that redeem a package or sub ID containing multiple app IDs, because Humble does not provide package IDs.

If the Steam account page cannot be loaded, cached ownership data can still be reused, but the script cannot automatically confirm whether the user changed Steam accounts.