### PR TITLE
feat: improve key revealing/export workflow and table data

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,12 +7,14 @@ import {
   getProducts,
   loadOrders,
   loadOwnedApps,
+  showErrorToast,
   showSteamAccountNotice,
   showSteamOwnedNotice,
   type Product,
 } from './util'
 
 import { Table } from './components/Table'
+import { captureTableState, type TableState } from './table-state'
 import { Refresh } from './components/Refresh'
 import { Actions } from './components/Actions'
 import type { Api } from 'datatables.net-dt'
@@ -24,8 +26,11 @@ export function App() {
     createSignal(false)
   const [pendingSteamAccountNotice, setPendingSteamAccountNotice] = createSignal(false)
   const [steamId, setSteamId] = createSignal<string | null>(null)
+  const [pendingTableState, setPendingTableState] = createSignal<TableState | null>(null)
+  const [dt, setDt] = createSignal<Api<Product> | null>(null)
 
   let checkSteamAccountTimer: number | undefined
+  let refreshInFlight: Promise<void> | null = null
 
   const refreshAfterSteamPageOpen = () => {
     window.setTimeout(() => refreshProducts(), 3000)
@@ -81,7 +86,7 @@ export function App() {
     }
   }
 
-  const [products, { refetch: refreshProducts }] = createResource<Product[], boolean>(
+  const [products, { refetch: refetchProducts }] = createResource<Product[], boolean>(
     async (_, info) => {
       console.debug('Loading products...')
       const orders = loadOrders()
@@ -123,7 +128,25 @@ export function App() {
     }
   )
 
-  const [dt, setDt] = createSignal<Api<Product> | null>(null)
+  const refreshProducts = (): Promise<void> => {
+    if (refreshInFlight) return refreshInFlight
+
+    const table = dt()
+    if (table) setPendingTableState(captureTableState(table))
+
+    refreshInFlight = (async () => {
+      try {
+        await refetchProducts()
+      } catch (error) {
+        setPendingTableState(null)
+        showErrorToast(error, 'Failed to refresh products')
+      } finally {
+        refreshInFlight = null
+      }
+    })()
+
+    return refreshInFlight
+  }
 
   onMount(() => {
     const checkSteamAccountChangedAfterVisibility = () => {
@@ -158,7 +181,15 @@ export function App() {
           <Refresh refresh={refreshProducts} />
         </div>
         <Show when={products()} keyed fallback={<p>Loading products...</p>}>
-          {(loadedProducts) => <Table products={loadedProducts} steamId={steamId} setDt={setDt} />}
+          {(loadedProducts) => (
+            <Table
+              products={loadedProducts}
+              steamId={steamId}
+              setDt={setDt}
+              initialState={pendingTableState()}
+              onStateRestored={() => setPendingTableState(null)}
+            />
+          )}
         </Show>
         <Actions dt={dt} />
       </div>

--- a/src/claim-report.ts
+++ b/src/claim-report.ts
@@ -35,6 +35,7 @@ export type ClaimReport<T extends ClaimProduct = ClaimProduct> = {
   typeCounts: ClaimTypeCount[]
   keylessCount: number
   exportCopied: boolean
+  exportEmpty: boolean
 }
 
 export type ClaimResultGroup<T extends ClaimProduct = ClaimProduct> = {

--- a/src/claim-report.ts
+++ b/src/claim-report.ts
@@ -2,6 +2,7 @@ export interface ClaimProduct {
   category_human_name: string
   direct_redeem: boolean
   human_name: string
+  is_expired?: boolean
   key_type: string
 }
 
@@ -23,6 +24,7 @@ export type ClaimPlan<T extends ClaimProduct = ClaimProduct> = {
   products: T[]
   typeCounts: ClaimTypeCount[]
   keylessCount: number
+  expiredCount: number
   bundleCount: number
 }
 
@@ -65,12 +67,14 @@ export const createClaimPlan = <T extends ClaimProduct>(products: T[]): ClaimPla
   const counts = new Map<string, number>()
   const bundles = new Set<string>()
   let keylessCount = 0
+  let expiredCount = 0
 
   for (const product of products) {
     const label = getClaimTypeLabel(product)
     counts.set(label, (counts.get(label) ?? 0) + 1)
     bundles.add(product.category_human_name || 'Unknown bundle')
     if (isKeylessProduct(product)) keylessCount++
+    if (product.is_expired) expiredCount++
   }
 
   return {
@@ -79,6 +83,7 @@ export const createClaimPlan = <T extends ClaimProduct>(products: T[]): ClaimPla
       (left, right) => right.count - left.count || left.label.localeCompare(right.label)
     ),
     keylessCount,
+    expiredCount,
     bundleCount: bundles.size,
   }
 }

--- a/src/claim-report.ts
+++ b/src/claim-report.ts
@@ -1,0 +1,143 @@
+export interface ClaimProduct {
+  category_human_name: string
+  direct_redeem: boolean
+  human_name: string
+  key_type: string
+}
+
+export type ClaimSuccess<T extends ClaimProduct = ClaimProduct> = {
+  index: number
+  product: T
+}
+
+export type ClaimFailure<T extends ClaimProduct = ClaimProduct> = ClaimSuccess<T> & {
+  error: unknown
+}
+
+export type ClaimTypeCount = {
+  label: string
+  count: number
+}
+
+export type ClaimPlan<T extends ClaimProduct = ClaimProduct> = {
+  products: T[]
+  typeCounts: ClaimTypeCount[]
+  keylessCount: number
+  bundleCount: number
+}
+
+export type ClaimReport<T extends ClaimProduct = ClaimProduct> = {
+  gift: boolean
+  successes: ClaimSuccess<T>[]
+  failures: ClaimFailure<T>[]
+  typeCounts: ClaimTypeCount[]
+  keylessCount: number
+  exportCopied: boolean
+}
+
+export type ClaimResultGroup<T extends ClaimProduct = ClaimProduct> = {
+  bundleName: string
+  successes: ClaimSuccess<T>[]
+  failures: ClaimFailure<T>[]
+}
+
+export const getErrorMessage = (error: unknown): string =>
+  error instanceof Error
+    ? error.message || 'Failed to reveal key'
+    : error == null
+      ? 'Failed to reveal key'
+      : String(error)
+
+export const isKeylessProduct = (product: ClaimProduct): boolean =>
+  product.direct_redeem || product.key_type.toLowerCase() === 'keyless'
+
+export const getClaimTypeLabel = (product: ClaimProduct): string => {
+  if (isKeylessProduct(product)) return 'Keyless (direct redemption)'
+
+  const type = product.key_type.trim()
+  if (!type) return 'Unknown'
+  if (type.toLowerCase() === 'gog') return 'GOG'
+
+  return type.charAt(0).toUpperCase() + type.slice(1)
+}
+
+export const createClaimPlan = <T extends ClaimProduct>(products: T[]): ClaimPlan<T> => {
+  const counts = new Map<string, number>()
+  const bundles = new Set<string>()
+  let keylessCount = 0
+
+  for (const product of products) {
+    const label = getClaimTypeLabel(product)
+    counts.set(label, (counts.get(label) ?? 0) + 1)
+    bundles.add(product.category_human_name || 'Unknown bundle')
+    if (isKeylessProduct(product)) keylessCount++
+  }
+
+  return {
+    products,
+    typeCounts: Array.from(counts, ([label, count]) => ({ label, count })).sort(
+      (left, right) => right.count - left.count || left.label.localeCompare(right.label)
+    ),
+    keylessCount,
+    bundleCount: bundles.size,
+  }
+}
+
+export const groupClaimResults = <T extends ClaimProduct>(
+  report: ClaimReport<T>
+): ClaimResultGroup<T>[] => {
+  const groups = new Map<string, ClaimResultGroup<T>>()
+  const results: Array<ClaimSuccess<T> | ClaimFailure<T>> = [
+    ...report.successes,
+    ...report.failures,
+  ].sort((left, right) => left.index - right.index)
+
+  for (const result of results) {
+    const bundleName = result.product.category_human_name || 'Unknown bundle'
+    let group = groups.get(bundleName)
+
+    if (!group) {
+      group = { bundleName, successes: [], failures: [] }
+      groups.set(bundleName, group)
+    }
+
+    if ('error' in result) {
+      group.failures.push(result)
+    } else {
+      group.successes.push(result)
+    }
+  }
+
+  return Array.from(groups.values())
+}
+
+export const formatClaimLog = <T extends ClaimProduct>(report: ClaimReport<T>): string => {
+  const requested = report.successes.length + report.failures.length
+  const action = report.gift ? 'Gift-link creation' : 'Key reveal'
+  const lines = [
+    `${action} results`,
+    `Requested: ${requested}`,
+    `Succeeded: ${report.successes.length}`,
+    `Failed: ${report.failures.length}`,
+    `Export copied to clipboard: ${report.exportCopied ? 'Yes' : 'No'}`,
+    `Keyless/direct-redemption items: ${report.keylessCount}`,
+    '',
+    'Type breakdown:',
+    ...report.typeCounts.map(({ label, count }) => `- ${label}: ${count}`),
+  ]
+
+  for (const group of groupClaimResults(report)) {
+    lines.push('', `Bundle: ${group.bundleName}`)
+
+    for (const { product } of group.successes) {
+      lines.push(`  SUCCESS - ${product.human_name} [${getClaimTypeLabel(product)}]`)
+    }
+
+    for (const { product, error } of group.failures) {
+      const type = getClaimTypeLabel(product)
+      lines.push(`  FAILED - ${product.human_name} [${type}]: ${getErrorMessage(error)}`)
+    }
+  }
+
+  return lines.join('\n')
+}

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -1,5 +1,12 @@
-import { createSignal, type Accessor } from 'solid-js'
+import { createSignal, onCleanup, Show, type Accessor } from 'solid-js'
 import type { Api } from 'datatables.net-dt'
+import {
+  createClaimPlan,
+  type ClaimFailure,
+  type ClaimPlan,
+  type ClaimReport,
+  type ClaimSuccess,
+} from '../claim-report'
 import { forEachConcurrent } from '../concurrency'
 import {
   hasSearchBuilderCriteria,
@@ -8,45 +15,47 @@ import {
 } from '../table-filter'
 import { hasRedeemedKeyValue, serializeRedeemedKeyValue } from '../redeemed-key'
 import { copyToClipboard, redeem, showErrorToast, showFlashToast, type Product } from '../util'
+import { BulkRevealConfirmation, BulkRevealResults } from './BulkRevealDialogs'
 // @ts-expect-error missing types
 import styles from '../style.module.css'
 
 const CLAIM_CONCURRENCY = 4
 
-type ClaimFailure = {
-  index: number
-  product: Product
-  error: unknown
+type PendingConfirmation = {
+  plan: ClaimPlan<Product>
+  gift: boolean
+  resolve: (confirmed: boolean) => void
 }
-
-const getErrorMessage = (error: unknown): string =>
-  error instanceof Error
-    ? error.message || 'Failed to reveal key'
-    : error == null
-      ? 'Failed to reveal key'
-      : String(error)
 
 const claimProducts = async (
   products: Product[],
   gift: boolean
-): Promise<{ failures: ClaimFailure[]; updated: Set<Product> }> => {
-  const claimable = products.filter((product) => !hasRedeemedKeyValue(product.redeemed_key_val))
-  const failures: ClaimFailure[] = []
+): Promise<{
+  successes: ClaimSuccess<Product>[]
+  failures: ClaimFailure<Product>[]
+  updated: Set<Product>
+}> => {
+  const successes: ClaimSuccess<Product>[] = []
+  const failures: ClaimFailure<Product>[] = []
   const updated = new Set<Product>()
-  await forEachConcurrent(claimable, CLAIM_CONCURRENCY, async (product, index) => {
+
+  await forEachConcurrent(products, CLAIM_CONCURRENCY, async (product, index) => {
     try {
       product.redeemed_key_val = await redeem(product, gift)
       product.type = gift ? 'Gift' : 'Key'
       product.is_gift = gift
       updated.add(product)
+      successes.push({ index, product })
     } catch (error) {
       console.error('Error redeeming product:', product.machine_name, error)
       failures.push({ index, product, error })
     }
   })
 
+  successes.sort((left, right) => left.index - right.index)
   failures.sort((left, right) => left.index - right.index)
-  return { failures, updated }
+
+  return { successes, failures, updated }
 }
 
 const exportASF = (products: Product[]): string =>
@@ -108,25 +117,29 @@ const exportCSV = (products: Product[], delimiter: string): string => {
   ].join('\r\n')
 }
 
-const formatClaimFailures = (failures: ClaimFailure[], gift: boolean): string => {
-  const item = gift ? 'gift link' : 'key'
-  const action = gift ? 'created' : 'revealed'
-
-  return [
-    `Exported to clipboard, but ${failures.length} ${item}${
-      failures.length === 1 ? '' : 's'
-    } could not be ${action}:`,
-    ...failures.map(({ product, error }) => `• ${product.human_name}: ${getErrorMessage(error)}`),
-  ].join('\n')
-}
-
 export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
   const [exportType, setExportType] = createSignal('csv')
-  const [filtered, setFiltered] = createSignal(true)
   const [claim, setClaim] = createSignal(false)
   const [claimType, setClaimType] = createSignal('key')
   const [exporting, setExporting] = createSignal(false)
   const [separator, setSeparator] = createSignal(',')
+  const [pendingConfirmation, setPendingConfirmation] = createSignal<PendingConfirmation | null>(
+    null
+  )
+  const [claimReport, setClaimReport] = createSignal<ClaimReport<Product> | null>(null)
+
+  const finishConfirmation = (confirmed: boolean): void => {
+    const pending = pendingConfirmation()
+    if (!pending) return
+
+    setPendingConfirmation(null)
+    pending.resolve(confirmed)
+  }
+
+  const confirmBulkReveal = (plan: ClaimPlan<Product>, gift: boolean): Promise<boolean> =>
+    new Promise((resolve) => setPendingConfirmation({ plan, gift, resolve }))
+
+  onCleanup(() => finishConfirmation(false))
 
   const invertFilter = (): void => {
     const table = dt()
@@ -155,21 +168,35 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
     setExporting(true)
 
     try {
-      const toExport = table
-        .rows({ search: filtered() ? 'applied' : 'none' })
-        .data()
-        .toArray() as Product[]
-
+      const toExport = table.rows({ search: 'applied' }).data().toArray() as Product[]
       const claimAsGift = claimType() === 'gift'
-      const { failures, updated } = claim()
-        ? await claimProducts(toExport, claimAsGift)
-        : { failures: [], updated: new Set<Product>() }
+      const claimable = claim()
+        ? toExport.filter((product) => !hasRedeemedKeyValue(product.redeemed_key_val))
+        : []
+      let report: ClaimReport<Product> | null = null
 
-      if (updated.size) {
-        table
-          .rows((_index, product) => updated.has(product))
-          .invalidate('data')
-          .draw(false)
+      if (claimable.length) {
+        const plan = createClaimPlan(claimable)
+        const confirmed = await confirmBulkReveal(plan, claimAsGift)
+        if (!confirmed) return
+
+        const { successes, failures, updated } = await claimProducts(claimable, claimAsGift)
+
+        if (updated.size) {
+          table
+            .rows((_index, product) => updated.has(product))
+            .invalidate('data')
+            .draw(false)
+        }
+
+        report = {
+          gift: claimAsGift,
+          successes,
+          failures,
+          typeCounts: plan.typeCounts,
+          keylessCount: plan.keylessCount,
+          exportCopied: false,
+        }
       }
 
       const delimiter = separator() || ','
@@ -179,12 +206,11 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
           : exportType() === 'keys'
             ? exportKeys(toExport)
             : exportCSV(toExport, delimiter)
+      const exportCopied = copyToClipboard(text)
 
-      if (!copyToClipboard(text)) return
-
-      if (failures.length) {
-        showErrorToast(formatClaimFailures(failures, claimAsGift))
-      } else {
+      if (report) {
+        setClaimReport({ ...report, exportCopied })
+      } else if (exportCopied) {
         showFlashToast('Exported to clipboard')
       }
     } catch (error) {
@@ -219,7 +245,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
             checked={claim()}
             onChange={(event) => setClaim(event.target.checked)}
           />
-          Claim unredeemed games
+          Reveal unrevealed keys
         </label>
         <select
           name="claimType"
@@ -245,16 +271,6 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
         >
           Invert filter
         </button>
-        <label for="filtered">
-          <input
-            type="checkbox"
-            id="filtered"
-            name="filtered"
-            checked={filtered()}
-            onChange={(event) => setFiltered(event.target.checked)}
-          />
-          Use table filter
-        </label>
         <select
           name="export"
           id="export"
@@ -275,6 +291,21 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
           {exporting() ? <i class="hb hb-spin hb-spinner"></i> : 'Export'}
         </button>
       </div>
+
+      <Show when={pendingConfirmation()} keyed>
+        {(pending) => (
+          <BulkRevealConfirmation
+            plan={pending.plan}
+            gift={pending.gift}
+            onCancel={() => finishConfirmation(false)}
+            onConfirm={() => finishConfirmation(true)}
+          />
+        )}
+      </Show>
+
+      <Show when={claimReport()} keyed>
+        {(report) => <BulkRevealResults report={report} onClose={() => setClaimReport(null)} />}
+      </Show>
     </>
   )
 }

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -101,13 +101,18 @@ const serializeField = (value: unknown): string => {
 const exportCSV = (products: Product[], delimiter: string): string => {
   if (!products.length) return ''
 
-  const header = Object.keys(products[0]).flatMap((name) =>
-    name === 'redeemed_date' ? ['redeemed_date_label', 'redeemed_date_iso'] : [name]
-  )
+  const header = Object.keys(products[0]).flatMap((name) => {
+    if (name === 'redeemed_date') return ['redeemed_date_label', 'redeemed_date_iso']
+    if (name === 'exclusive_countries') return ['Exclusive Countries']
+    if (name === 'disallowed_countries') return ['Disallowed Countries']
+    return [name]
+  })
 
   const getCsvValue = (product: Product, name: string): unknown => {
     if (name === 'redeemed_date_label') return product.redeemed_date?.label ?? ''
     if (name === 'redeemed_date_iso') return product.redeemed_date?.iso ?? ''
+    if (name === 'Exclusive Countries') return product.exclusive_countries.join(';')
+    if (name === 'Disallowed Countries') return product.disallowed_countries.join(';')
     return product[name as keyof Product]
   }
 

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -121,8 +121,18 @@ const exportCSV = (products: Product[], delimiter: string): string => {
   ].join('\r\n')
 }
 
+type ExportType = 'asf' | 'keys' | 'csv'
+
+const getEmptyExportMessage = (type: ExportType, products: Product[]): string => {
+  if (!products.length) return 'Empty export: no rows in table'
+  if (type === 'asf') return 'Empty export: no revealed Steam keys in table'
+  if (type === 'keys') return 'Empty export: no revealed keys in table'
+
+  return 'Empty export'
+}
+
 export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
-  const [exportType, setExportType] = createSignal('csv')
+  const [exportType, setExportType] = createSignal<ExportType>('csv')
   const [claim, setClaim] = createSignal(false)
   const [claimType, setClaimType] = createSignal('key')
   const [exporting, setExporting] = createSignal(false)
@@ -226,6 +236,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
           typeCounts: plan.typeCounts,
           keylessCount: plan.keylessCount,
           exportCopied: false,
+          exportEmpty: false,
         }
       }
 
@@ -236,6 +247,16 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
           : exportType() === 'keys'
             ? exportKeys(toExport)
             : exportCSV(toExport, delimiter)
+      if (!text) {
+        showFlashToast(getEmptyExportMessage(exportType(), toExport), 'warning')
+
+        if (report) {
+          setPendingConfirmation(null)
+          setClaimReport({ ...report, exportCopied: false, exportEmpty: true })
+        }
+        return
+      }
+
       const exportCopied = copyToClipboard(text)
 
       if (report) {
@@ -309,7 +330,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
           id="export"
           class={styles.select}
           value={exportType()}
-          onChange={(event) => setExportType(event.target.value)}
+          onChange={(event) => setExportType(event.currentTarget.value as ExportType)}
         >
           <option value="asf">ASF</option>
           <option value="keys">Keys</option>

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -1,10 +1,126 @@
 import { createSignal, type Accessor } from 'solid-js'
-import { redeem, showFlashToast, type Product } from '../util'
+import type { Api } from 'datatables.net-dt'
+import { forEachConcurrent } from '../concurrency'
+import {
+  hasSearchBuilderCriteria,
+  invertSearchBuilderGroup,
+  type WithSearchBuilder,
+} from '../table-filter'
+import { hasRedeemedKeyValue, serializeRedeemedKeyValue } from '../redeemed-key'
+import { copyToClipboard, redeem, showErrorToast, showFlashToast, type Product } from '../util'
 // @ts-expect-error missing types
 import styles from '../style.module.css'
-import type { Api } from 'datatables.net-dt'
 
-export function Actions({ dt }: { dt: Accessor<Api<Product>> }) {
+const CLAIM_CONCURRENCY = 4
+
+type ClaimFailure = {
+  index: number
+  product: Product
+  error: unknown
+}
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error
+    ? error.message || 'Failed to reveal key'
+    : error == null
+      ? 'Failed to reveal key'
+      : String(error)
+
+const claimProducts = async (
+  products: Product[],
+  gift: boolean
+): Promise<{ failures: ClaimFailure[]; updated: Set<Product> }> => {
+  const claimable = products.filter((product) => !hasRedeemedKeyValue(product.redeemed_key_val))
+  const failures: ClaimFailure[] = []
+  const updated = new Set<Product>()
+  await forEachConcurrent(claimable, CLAIM_CONCURRENCY, async (product, index) => {
+    try {
+      product.redeemed_key_val = await redeem(product, gift)
+      product.type = gift ? 'Gift' : 'Key'
+      product.is_gift = gift
+      updated.add(product)
+    } catch (error) {
+      console.error('Error redeeming product:', product.machine_name, error)
+      failures.push({ index, product, error })
+    }
+  })
+
+  failures.sort((left, right) => left.index - right.index)
+  return { failures, updated }
+}
+
+const exportASF = (products: Product[]): string =>
+  products
+    .filter(
+      (product) =>
+        !product.is_gift &&
+        hasRedeemedKeyValue(product.redeemed_key_val) &&
+        product.key_type === 'steam'
+    )
+    .map(
+      (product) => `${product.human_name}\t${serializeRedeemedKeyValue(product.redeemed_key_val)}`
+    )
+    .join('\n')
+
+const exportKeys = (products: Product[]): string =>
+  products
+    .filter((product) => !product.is_gift && hasRedeemedKeyValue(product.redeemed_key_val))
+    .map((product) => serializeRedeemedKeyValue(product.redeemed_key_val))
+    .join('\n')
+
+const escapeCsvField = (value: string, delimiter: string): string => {
+  const needsQuotes =
+    value.includes('"') ||
+    value.includes('\n') ||
+    value.includes('\r') ||
+    (delimiter ? value.includes(delimiter) : false) ||
+    value.trim() !== value
+
+  return needsQuotes ? `"${value.replace(/"/g, '""')}"` : value
+}
+
+const serializeField = (value: unknown): string => {
+  if (value == null) return ''
+  if (typeof value === 'object') return JSON.stringify(value) ?? ''
+  return String(value)
+}
+
+const exportCSV = (products: Product[], delimiter: string): string => {
+  if (!products.length) return ''
+
+  const header = Object.keys(products[0]).flatMap((name) =>
+    name === 'redeemed_date' ? ['redeemed_date_label', 'redeemed_date_iso'] : [name]
+  )
+
+  const getCsvValue = (product: Product, name: string): unknown => {
+    if (name === 'redeemed_date_label') return product.redeemed_date?.label ?? ''
+    if (name === 'redeemed_date_iso') return product.redeemed_date?.iso ?? ''
+    return product[name as keyof Product]
+  }
+
+  return [
+    header.map((name) => escapeCsvField(name, delimiter)).join(delimiter),
+    ...products.map((product) =>
+      header
+        .map((name) => escapeCsvField(serializeField(getCsvValue(product, name)), delimiter))
+        .join(delimiter)
+    ),
+  ].join('\r\n')
+}
+
+const formatClaimFailures = (failures: ClaimFailure[], gift: boolean): string => {
+  const item = gift ? 'gift link' : 'key'
+  const action = gift ? 'created' : 'revealed'
+
+  return [
+    `Exported to clipboard, but ${failures.length} ${item}${
+      failures.length === 1 ? '' : 's'
+    } could not be ${action}:`,
+    ...failures.map(({ product, error }) => `• ${product.human_name}: ${getErrorMessage(error)}`),
+  ].join('\n')
+}
+
+export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
   const [exportType, setExportType] = createSignal('csv')
   const [filtered, setFiltered] = createSignal(true)
   const [claim, setClaim] = createSignal(false)
@@ -12,106 +128,70 @@ export function Actions({ dt }: { dt: Accessor<Api<Product>> }) {
   const [exporting, setExporting] = createSignal(false)
   const [separator, setSeparator] = createSignal(',')
 
-  const exportASF = (products: Product[]) => {
-    const keys = products
-      .filter(
-        (product) => !product.is_gift && product.redeemed_key_val && product.key_type === 'steam'
-      )
-      .map((product) => `${product.human_name}\t${product.redeemed_key_val}`)
-      .join('\n')
+  const invertFilter = (): void => {
+    const table = dt()
+    if (!table) return
 
-    navigator.clipboard.writeText(keys)
-  }
+    try {
+      const searchBuilder = (table as WithSearchBuilder<Api<Product>>).searchBuilder
+      const details = searchBuilder.getDetails(true)
 
-  const exportKeys = (products: Product[]) => {
-    const keys = products
-      .filter((product) => !product.is_gift && product.redeemed_key_val)
-      .map((product) => product.redeemed_key_val)
-      .join('\n')
-
-    navigator.clipboard.writeText(keys)
-  }
-
-  const escapeCsvField = (value: unknown, delim: string) => {
-    const s = value == null ? '' : String(value)
-    const needsQuotes =
-      s.includes('"') ||
-      s.includes('\n') ||
-      s.includes('\r') ||
-      (delim ? s.includes(delim) : false) ||
-      s.trim() !== s
-
-    return needsQuotes ? `"${s.replace(/"/g, '""')}"` : s
-  }
-
-  const serializeField = (value: unknown): string => {
-    if (value == null) return ''
-    return String(value)
-  }
-
-  const exportCSV = (products: Product[]) => {
-    if (!products.length) {
-      navigator.clipboard.writeText('')
-      return
-    }
-
-    const delim = separator() || ','
-    const header = Object.keys(products[0]).flatMap((h) =>
-      h === 'redeemed_date' ? ['redeemed_date_label', 'redeemed_date_iso'] : [h]
-    )
-
-    const getCsvValue = (product: Product, header: string): unknown => {
-      if (header === 'redeemed_date_label') return product.redeemed_date?.label ?? ''
-      if (header === 'redeemed_date_iso') return product.redeemed_date?.iso ?? ''
-
-      return product[header as keyof Product]
-    }
-
-    const lines = [
-      header.map((h) => escapeCsvField(h, delim)).join(delim),
-      ...products.map((product) =>
-        header
-          .map((h) => escapeCsvField(serializeField(getCsvValue(product, h)), delim))
-          .join(delim)
-      ),
-    ]
-
-    navigator.clipboard.writeText(lines.join('\r\n'))
-  }
-
-  const exportToClipboard = async () => {
-    setExporting(true)
-    const toExport = dt()
-      .rows({ search: filtered() ? 'applied' : 'none' })
-      .data()
-      .toArray() as Product[]
-
-    if (claim()) {
-      for (const product of toExport) {
-        if (product.redeemed_key_val) {
-          continue
-        }
-        try {
-          product.redeemed_key_val = await redeem(product, claimType() === 'gift')
-        } catch (e) {
-          console.error('Error redeeming product:', product.machine_name, e)
-        }
+      if (!hasSearchBuilderCriteria(details)) {
+        throw new Error('Add at least one table filter before inverting it.')
       }
-    }
 
-    switch (exportType()) {
-      case 'asf':
-        exportASF(toExport)
-        break
-      case 'keys':
-        exportKeys(toExport)
-        break
-      case 'csv':
-        exportCSV(toExport)
-        break
+      searchBuilder.rebuild(invertSearchBuilderGroup(details), false)
+      table.draw(false)
+      showFlashToast('Table filter inverted')
+    } catch (error) {
+      showErrorToast(error, 'Failed to invert table filter')
     }
-    setExporting(false)
-    showFlashToast('Exported to clipboard')
+  }
+
+  const exportToClipboard = async (): Promise<void> => {
+    const table = dt()
+    if (!table) return
+
+    setExporting(true)
+
+    try {
+      const toExport = table
+        .rows({ search: filtered() ? 'applied' : 'none' })
+        .data()
+        .toArray() as Product[]
+
+      const claimAsGift = claimType() === 'gift'
+      const { failures, updated } = claim()
+        ? await claimProducts(toExport, claimAsGift)
+        : { failures: [], updated: new Set<Product>() }
+
+      if (updated.size) {
+        table
+          .rows((_index, product) => updated.has(product))
+          .invalidate('data')
+          .draw(false)
+      }
+
+      const delimiter = separator() || ','
+      const text =
+        exportType() === 'asf'
+          ? exportASF(toExport)
+          : exportType() === 'keys'
+            ? exportKeys(toExport)
+            : exportCSV(toExport, delimiter)
+
+      if (!copyToClipboard(text)) return
+
+      if (failures.length) {
+        showErrorToast(formatClaimFailures(failures, claimAsGift))
+      } else {
+        showFlashToast('Exported to clipboard')
+      }
+    } catch (error) {
+      showErrorToast(error, 'Export failed')
+    } finally {
+      setExporting(false)
+    }
   }
 
   return (
@@ -124,7 +204,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product>> }) {
             name="separator"
             id="separator"
             value=","
-            onInput={(e) => setSeparator(e.target.value)}
+            onInput={(event) => setSeparator(event.target.value)}
             style={{ width: '5ch', 'text-align': 'center' }}
             required
           />
@@ -137,7 +217,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product>> }) {
             id="claim"
             name="claim"
             checked={claim()}
-            onChange={(e) => setClaim(e.target.checked)}
+            onChange={(event) => setClaim(event.target.checked)}
           />
           Claim unredeemed games
         </label>
@@ -146,7 +226,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product>> }) {
           id="claimType"
           class={styles.select}
           classList={{ hidden: !claim() }}
-          onChange={(e) => setClaimType(e.target.value)}
+          onChange={(event) => setClaimType(event.target.value)}
         >
           <option value="" disabled>
             What to claim
@@ -156,13 +236,22 @@ export function Actions({ dt }: { dt: Accessor<Api<Product>> }) {
           </option>
           <option value="gift">Gift link</option>
         </select>
+        <button
+          type="button"
+          class={styles.btn}
+          onClick={invertFilter}
+          disabled={!dt() || exporting()}
+          title="Replace the current advanced filter with its logical opposite"
+        >
+          Invert filter
+        </button>
         <label for="filtered">
           <input
             type="checkbox"
             id="filtered"
             name="filtered"
             checked={filtered()}
-            onChange={(e) => setFiltered(e.target.checked)}
+            onChange={(event) => setFiltered(event.target.checked)}
           />
           Use table filter
         </label>
@@ -171,7 +260,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product>> }) {
           id="export"
           class={styles.select}
           value={exportType()}
-          onChange={(e) => setExportType(e.target.value)}
+          onChange={(event) => setExportType(event.target.value)}
         >
           <option value="asf">ASF</option>
           <option value="keys">Keys</option>
@@ -181,7 +270,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product>> }) {
           type="button"
           class="primary-button"
           onClick={exportToClipboard}
-          disabled={!exportType() || exporting()}
+          disabled={!dt() || !exportType() || exporting()}
         >
           {exporting() ? <i class="hb hb-spin hb-spinner"></i> : 'Export'}
         </button>

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -19,7 +19,7 @@ import { BulkRevealConfirmation, BulkRevealResults } from './BulkRevealDialogs'
 // @ts-expect-error missing types
 import styles from '../style.module.css'
 
-const CLAIM_CONCURRENCY = 4
+const CLAIM_CONCURRENCY = 5
 
 type PendingConfirmation = {
   plan: ClaimPlan<Product>
@@ -29,7 +29,8 @@ type PendingConfirmation = {
 
 const claimProducts = async (
   products: Product[],
-  gift: boolean
+  gift: boolean,
+  onProgress?: (completed: number) => void
 ): Promise<{
   successes: ClaimSuccess<Product>[]
   failures: ClaimFailure<Product>[]
@@ -38,6 +39,7 @@ const claimProducts = async (
   const successes: ClaimSuccess<Product>[] = []
   const failures: ClaimFailure<Product>[] = []
   const updated = new Set<Product>()
+  let completed = 0
 
   await forEachConcurrent(products, CLAIM_CONCURRENCY, async (product, index) => {
     try {
@@ -49,6 +51,8 @@ const claimProducts = async (
     } catch (error) {
       console.error('Error redeeming product:', product.machine_name, error)
       failures.push({ index, product, error })
+    } finally {
+      onProgress?.(++completed)
     }
   })
 
@@ -122,24 +126,39 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
   const [claim, setClaim] = createSignal(false)
   const [claimType, setClaimType] = createSignal('key')
   const [exporting, setExporting] = createSignal(false)
+  const [bulkRevealProcessing, setBulkRevealProcessing] = createSignal(false)
+  const [bulkRevealProgress, setBulkRevealProgress] = createSignal(0)
   const [separator, setSeparator] = createSignal(',')
   const [pendingConfirmation, setPendingConfirmation] = createSignal<PendingConfirmation | null>(
     null
   )
   const [claimReport, setClaimReport] = createSignal<ClaimReport<Product> | null>(null)
 
-  const finishConfirmation = (confirmed: boolean): void => {
+  const cancelConfirmation = (): void => {
+    if (bulkRevealProcessing()) return
+
     const pending = pendingConfirmation()
     if (!pending) return
 
     setPendingConfirmation(null)
-    pending.resolve(confirmed)
+    pending.resolve(false)
   }
 
-  const confirmBulkReveal = (plan: ClaimPlan<Product>, gift: boolean): Promise<boolean> =>
-    new Promise((resolve) => setPendingConfirmation({ plan, gift, resolve }))
+  const confirmReveal = (): void => {
+    const pending = pendingConfirmation()
+    if (!pending || bulkRevealProcessing()) return
 
-  onCleanup(() => finishConfirmation(false))
+    setBulkRevealProcessing(true)
+    pending.resolve(true)
+  }
+
+  const confirmBulkReveal = (plan: ClaimPlan<Product>, gift: boolean): Promise<boolean> => {
+    setBulkRevealProcessing(false)
+    setBulkRevealProgress(0)
+    return new Promise((resolve) => setPendingConfirmation({ plan, gift, resolve }))
+  }
+
+  onCleanup(() => pendingConfirmation()?.resolve(false))
 
   const invertFilter = (): void => {
     const table = dt()
@@ -150,7 +169,14 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
       const details = searchBuilder.getDetails(true)
 
       if (!hasSearchBuilderCriteria(details)) {
-        throw new Error('Add at least one table filter before inverting it.')
+        const hasTextSearch =
+          Boolean(table.search()) || table.columns().search().toArray().some(Boolean)
+
+        throw new Error(
+          hasTextSearch
+            ? 'Invert filter only supports conditions created with "Add Condition"; text searches cannot be inverted.'
+            : 'Add at least one condition with "Add Condition" before inverting the filter.'
+        )
       }
 
       searchBuilder.rebuild(invertSearchBuilderGroup(details), false)
@@ -180,7 +206,11 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
         const confirmed = await confirmBulkReveal(plan, claimAsGift)
         if (!confirmed) return
 
-        const { successes, failures, updated } = await claimProducts(claimable, claimAsGift)
+        const { successes, failures, updated } = await claimProducts(
+          claimable,
+          claimAsGift,
+          setBulkRevealProgress
+        )
 
         if (updated.size) {
           table
@@ -209,6 +239,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
       const exportCopied = copyToClipboard(text)
 
       if (report) {
+        setPendingConfirmation(null)
         setClaimReport({ ...report, exportCopied })
       } else if (exportCopied) {
         showFlashToast('Exported to clipboard')
@@ -216,6 +247,8 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
     } catch (error) {
       showErrorToast(error, 'Export failed')
     } finally {
+      setPendingConfirmation(null)
+      setBulkRevealProcessing(false)
       setExporting(false)
     }
   }
@@ -237,7 +270,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
         </label>
       </div>
       <div class={styles.actions}>
-        <label for="claim">
+        <label for="claim" class={styles.checkbox_label}>
           <input
             type="checkbox"
             id="claim"
@@ -267,7 +300,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
           class={styles.btn}
           onClick={invertFilter}
           disabled={!dt() || exporting()}
-          title="Replace the current advanced filter with its logical opposite"
+          title="Invert conditions created with Add Condition"
         >
           Invert filter
         </button>
@@ -288,7 +321,11 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
           onClick={exportToClipboard}
           disabled={!dt() || !exportType() || exporting()}
         >
-          {exporting() ? <i class="hb hb-spin hb-spinner"></i> : 'Export'}
+          {exporting() && !pendingConfirmation() && !bulkRevealProcessing() ? (
+            <i class="hb hb-spin hb-spinner"></i>
+          ) : (
+            'Export'
+          )}
         </button>
       </div>
 
@@ -297,8 +334,10 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
           <BulkRevealConfirmation
             plan={pending.plan}
             gift={pending.gift}
-            onCancel={() => finishConfirmation(false)}
-            onConfirm={() => finishConfirmation(true)}
+            processing={bulkRevealProcessing}
+            progress={bulkRevealProgress}
+            onCancel={cancelConfirmation}
+            onConfirm={confirmReveal}
           />
         )}
       </Show>

--- a/src/components/BulkRevealDialogs.tsx
+++ b/src/components/BulkRevealDialogs.tsx
@@ -1,0 +1,288 @@
+import { For, Show } from 'solid-js'
+import {
+  formatClaimLog,
+  getClaimTypeLabel,
+  getErrorMessage,
+  groupClaimResults,
+  type ClaimPlan,
+  type ClaimReport,
+} from '../claim-report'
+import { copyToClipboard, showFlashToast, type Product } from '../util'
+// @ts-expect-error missing types
+import styles from '../style.module.css'
+
+const pluralize = (count: number, singular: string, plural = `${singular}s`): string =>
+  count === 1 ? singular : plural
+
+export function BulkRevealConfirmation({
+  plan,
+  gift,
+  onCancel,
+  onConfirm,
+}: {
+  plan: ClaimPlan<Product>
+  gift: boolean
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  const count = plan.products.length
+  const action = gift ? 'create gift links for' : 'reveal'
+  const keylessWarning = gift
+    ? [
+        'These may redeem directly to the third-party account linked to your Humble Bundle',
+        'account instead of producing transferable gift links.',
+      ].join(' ')
+    : [
+        'Revealing them will redeem them immediately to the third-party account linked to',
+        'your Humble Bundle account; they will not produce transferable keys.',
+      ].join(' ')
+
+  return (
+    <div
+      class={styles.modal_backdrop}
+      role="presentation"
+      onMouseDown={(event) => event.target === event.currentTarget && onCancel()}
+      onKeyDown={(event) => event.key === 'Escape' && onCancel()}
+    >
+      <section
+        class={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="hb_extractor-confirm-title"
+        tabindex="-1"
+      >
+        <header class={styles.modal_header}>
+          <div>
+            <p class={styles.modal_eyebrow}>Bulk reveal confirmation</p>
+            <h2 id="hb_extractor-confirm-title" class={styles.modal_title}>
+              {gift ? 'Create gift links and export?' : 'Reveal keys and export?'}
+            </h2>
+          </div>
+          <button
+            type="button"
+            class={styles.modal_close}
+            aria-label="Cancel"
+            title="Cancel"
+            onClick={onCancel}
+          >
+            ×
+          </button>
+        </header>
+
+        <div class={styles.modal_body}>
+          <p class={styles.modal_lead}>
+            The exporter is about to {action} <strong>{count}</strong>{' '}
+            {pluralize(count, 'unrevealed item')} across <strong>{plan.bundleCount}</strong>{' '}
+            {pluralize(plan.bundleCount, 'bundle')}.
+          </p>
+
+          <div class={styles.modal_stats}>
+            <div class={styles.modal_stat}>
+              <strong>{count}</strong>
+              <span>Items</span>
+            </div>
+            <div class={styles.modal_stat}>
+              <strong>{plan.bundleCount}</strong>
+              <span>Bundles</span>
+            </div>
+            <div class={styles.modal_stat}>
+              <strong>{plan.typeCounts.length}</strong>
+              <span>Types</span>
+            </div>
+          </div>
+
+          <div class={styles.type_breakdown}>
+            <h3>Type breakdown</h3>
+            <ul>
+              <For each={plan.typeCounts}>
+                {({ label, count: typeCount }) => (
+                  <li>
+                    <span>{label}</span>
+                    <strong>{typeCount}</strong>
+                  </li>
+                )}
+              </For>
+            </ul>
+          </div>
+
+          <Show when={plan.keylessCount > 0}>
+            <div class={styles.modal_warning} role="alert">
+              <strong>Keyless redemption warning</strong>
+              <p>
+                {plan.keylessCount} {pluralize(plan.keylessCount, 'item')} Humble marks for direct
+                redemption. {keylessWarning} Verify that the correct account is linked before
+                continuing.
+              </p>
+            </div>
+          </Show>
+
+          <p class={styles.modal_note}>Nothing will be revealed or exported unless you confirm.</p>
+        </div>
+
+        <footer class={styles.modal_footer}>
+          <button type="button" class={styles.modal_secondary_button} onClick={onCancel}>
+            Cancel
+          </button>
+          <button type="button" class={styles.modal_primary_button} onClick={onConfirm} autofocus>
+            {gift ? 'Create & Export' : 'Reveal & Export'}
+          </button>
+        </footer>
+      </section>
+    </div>
+  )
+}
+
+export function BulkRevealResults({
+  report,
+  onClose,
+}: {
+  report: ClaimReport<Product>
+  onClose: () => void
+}) {
+  const groups = groupClaimResults(report)
+  const requested = report.successes.length + report.failures.length
+
+  const copyLog = (): void => {
+    if (copyToClipboard(formatClaimLog(report))) {
+      showFlashToast('Log copied to clipboard')
+    }
+  }
+
+  return (
+    <div
+      class={styles.modal_backdrop}
+      role="presentation"
+      onKeyDown={(event) => event.key === 'Escape' && onClose()}
+    >
+      <section
+        class={`${styles.modal} ${styles.modal_wide}`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="hb_extractor-results-title"
+        tabindex="-1"
+      >
+        <header class={styles.modal_header}>
+          <div>
+            <p class={styles.modal_eyebrow}>Bulk reveal complete</p>
+            <h2 id="hb_extractor-results-title" class={styles.modal_title}>
+              Reveal results
+            </h2>
+          </div>
+          <button
+            type="button"
+            class={styles.modal_close}
+            aria-label="Close results"
+            title="Close"
+            onClick={onClose}
+          >
+            ×
+          </button>
+        </header>
+
+        <div class={styles.modal_body}>
+          <div class={styles.result_summary} aria-live="polite">
+            <div class={styles.result_summary_item}>
+              <strong>{requested}</strong>
+              <span>Attempted</span>
+            </div>
+            <div class={`${styles.result_summary_item} ${styles.result_success_summary}`}>
+              <strong>{report.successes.length}</strong>
+              <span>Succeeded</span>
+            </div>
+            <div class={`${styles.result_summary_item} ${styles.result_failure_summary}`}>
+              <strong>{report.failures.length}</strong>
+              <span>Failed</span>
+            </div>
+          </div>
+
+          <div
+            class={`${styles.export_status} ${
+              report.exportCopied ? styles.export_status_success : styles.export_status_failure
+            }`}
+          >
+            {report.exportCopied ? (
+              <>
+                Export copied to clipboard. <strong>Paste it before copying the log.</strong>
+              </>
+            ) : (
+              'The reveal finished, but the export could not be copied to your clipboard.'
+            )}
+          </div>
+
+          <div class={styles.result_groups}>
+            <For each={groups}>
+              {(group) => (
+                <details class={styles.result_bundle} open={group.failures.length > 0}>
+                  <summary>
+                    <span>{group.bundleName}</span>
+                    <span class={styles.result_bundle_counts}>
+                      <span class={styles.result_count_success}>
+                        {group.successes.length} succeeded
+                      </span>
+                      <Show when={group.failures.length > 0}>
+                        <span class={styles.result_count_failure}>
+                          {group.failures.length} failed
+                        </span>
+                      </Show>
+                    </span>
+                  </summary>
+
+                  <div class={styles.result_bundle_body}>
+                    <Show when={group.successes.length > 0}>
+                      <h4>Successfully revealed</h4>
+                      <ul class={styles.result_list}>
+                        <For each={group.successes}>
+                          {({ product }) => (
+                            <li class={styles.result_success}>
+                              <span class={styles.result_icon} aria-hidden="true">
+                                ✓
+                              </span>
+                              <span>
+                                <strong>{product.human_name}</strong>
+                                <small>{getClaimTypeLabel(product)}</small>
+                              </span>
+                            </li>
+                          )}
+                        </For>
+                      </ul>
+                    </Show>
+
+                    <Show when={group.failures.length > 0}>
+                      <h4>Failed</h4>
+                      <ul class={styles.result_list}>
+                        <For each={group.failures}>
+                          {({ product, error }) => (
+                            <li class={styles.result_failure}>
+                              <span class={styles.result_icon} aria-hidden="true">
+                                ×
+                              </span>
+                              <span>
+                                <strong>{product.human_name}</strong>
+                                <small>
+                                  {getClaimTypeLabel(product)} — {getErrorMessage(error)}
+                                </small>
+                              </span>
+                            </li>
+                          )}
+                        </For>
+                      </ul>
+                    </Show>
+                  </div>
+                </details>
+              )}
+            </For>
+          </div>
+        </div>
+
+        <footer class={styles.modal_footer}>
+          <button type="button" class={styles.modal_secondary_button} onClick={onClose}>
+            Close
+          </button>
+          <button type="button" class={styles.modal_primary_button} onClick={copyLog} autofocus>
+            Copy Log
+          </button>
+        </footer>
+      </section>
+    </div>
+  )
+}

--- a/src/components/BulkRevealDialogs.tsx
+++ b/src/components/BulkRevealDialogs.tsx
@@ -296,6 +296,16 @@ export function BulkRevealConfirmation({
             </div>
           </Show>
 
+          <Show when={plan.expiredCount > 0}>
+            <div class={styles.modal_warning} role="alert">
+              <strong>Expired-item warning</strong>
+              <p>
+                {plan.expiredCount} {pluralize(plan.expiredCount, 'item')} Humble marks as expired.
+                These requests may fail, but the exporter will attempt them if you continue.
+              </p>
+            </div>
+          </Show>
+
           <p class={styles.modal_note} aria-live="polite">
             {processing()
               ? 'Keep this window open while the reveal and export complete.'

--- a/src/components/BulkRevealDialogs.tsx
+++ b/src/components/BulkRevealDialogs.tsx
@@ -416,13 +416,19 @@ export function BulkRevealResults({
 
           <div
             class={`${styles.export_status} ${
-              report.exportCopied ? styles.export_status_success : styles.export_status_failure
+              report.exportCopied
+                ? styles.export_status_success
+                : report.exportEmpty
+                  ? styles.export_status_warning
+                  : styles.export_status_failure
             }`}
           >
             {report.exportCopied ? (
               <>
                 Export copied to clipboard. <strong>Paste it before copying the log.</strong>
               </>
+            ) : report.exportEmpty ? (
+              'The reveal finished, but the selected export was empty. Your clipboard was left unchanged.'
             ) : (
               'The reveal finished, but the export could not be copied to your clipboard.'
             )}

--- a/src/components/BulkRevealDialogs.tsx
+++ b/src/components/BulkRevealDialogs.tsx
@@ -4,6 +4,7 @@ import {
   getClaimTypeLabel,
   getErrorMessage,
   groupClaimResults,
+  isKeylessProduct,
   type ClaimPlan,
   type ClaimReport,
 } from '../claim-report'
@@ -13,6 +14,34 @@ import styles from '../style.module.css'
 
 const pluralize = (count: number, singular: string, plural = `${singular}s`): string =>
   count === 1 ? singular : plural
+
+const claimTypeIconClasses: Record<string, string> = {
+  battlenet: 'hb-bnet',
+  epic: 'hb-epic',
+  epicgames: 'hb-epic',
+  gog: 'hb-gog',
+  oculus: 'hb-oculus',
+  origin: 'hb-origin',
+  steam: 'hb-steam',
+  ubisoft: 'hb-uplay',
+  ubisoftconnect: 'hb-uplay',
+  uplay: 'hb-uplay',
+}
+
+const ClaimType = ({ product }: { product: Product }) => {
+  const iconClass = isKeylessProduct(product)
+    ? 'hb-link'
+    : claimTypeIconClasses[product.key_type.toLowerCase().replace(/[^a-z0-9]/g, '')]
+
+  return (
+    <span class={styles.result_type}>
+      {iconClass ? (
+        <i class={`hb ${iconClass} ${styles.result_type_icon}`} aria-hidden="true"></i>
+      ) : null}
+      <span>{getClaimTypeLabel(product)}</span>
+    </span>
+  )
+}
 
 const useEscapeKey = (onEscape: () => void, disabled?: Accessor<boolean>): void => {
   const handleKeyDown = (event: KeyboardEvent): void => {
@@ -316,8 +345,15 @@ export function BulkRevealResults({
 }) {
   const groups = groupClaimResults(report)
   const requested = report.successes.length + report.failures.length
+  let resultGroupsRef!: HTMLDivElement
 
   useEscapeKey(onClose)
+
+  const setAllBundlesOpen = (open: boolean): void => {
+    for (const bundle of resultGroupsRef.querySelectorAll<HTMLDetailsElement>('details')) {
+      bundle.open = open
+    }
+  }
 
   const copyLog = (): void => {
     if (copyToClipboard(formatClaimLog(report))) {
@@ -382,10 +418,32 @@ export function BulkRevealResults({
             )}
           </div>
 
-          <div class={styles.result_groups}>
+          <Show when={groups.length > 1}>
+            <div class={styles.result_group_controls}>
+              <button
+                type="button"
+                class={styles.result_group_button}
+                onClick={() => setAllBundlesOpen(true)}
+              >
+                Expand all
+              </button>
+              <button
+                type="button"
+                class={styles.result_group_button}
+                onClick={() => setAllBundlesOpen(false)}
+              >
+                Collapse all
+              </button>
+            </div>
+          </Show>
+
+          <div ref={resultGroupsRef} class={styles.result_groups}>
             <For each={groups}>
               {(group) => (
-                <details class={styles.result_bundle} open={group.failures.length > 0}>
+                <details
+                  class={styles.result_bundle}
+                  open={groups.length === 1 || group.failures.length > 0}
+                >
                   <summary>
                     <span>{group.bundleName}</span>
                     <span class={styles.result_bundle_counts}>
@@ -412,7 +470,9 @@ export function BulkRevealResults({
                               </span>
                               <span>
                                 <strong>{product.human_name}</strong>
-                                <small>{getClaimTypeLabel(product)}</small>
+                                <small>
+                                  <ClaimType product={product} />
+                                </small>
                               </span>
                             </li>
                           )}
@@ -432,7 +492,7 @@ export function BulkRevealResults({
                               <span>
                                 <strong>{product.human_name}</strong>
                                 <small>
-                                  {getClaimTypeLabel(product)} — {getErrorMessage(error)}
+                                  <ClaimType product={product} /> — {getErrorMessage(error)}
                                 </small>
                               </span>
                             </li>

--- a/src/components/BulkRevealDialogs.tsx
+++ b/src/components/BulkRevealDialogs.tsx
@@ -1,4 +1,4 @@
-import { For, Show } from 'solid-js'
+import { For, onCleanup, onMount, Show, type Accessor } from 'solid-js'
 import {
   formatClaimLog,
   getClaimTypeLabel,
@@ -14,14 +14,30 @@ import styles from '../style.module.css'
 const pluralize = (count: number, singular: string, plural = `${singular}s`): string =>
   count === 1 ? singular : plural
 
+const useEscapeKey = (onEscape: () => void, disabled?: Accessor<boolean>): void => {
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    if (event.key !== 'Escape' || disabled?.()) return
+
+    event.preventDefault()
+    onEscape()
+  }
+
+  onMount(() => document.addEventListener('keydown', handleKeyDown))
+  onCleanup(() => document.removeEventListener('keydown', handleKeyDown))
+}
+
 export function BulkRevealConfirmation({
   plan,
   gift,
+  processing,
+  progress,
   onCancel,
   onConfirm,
 }: {
   plan: ClaimPlan<Product>
   gift: boolean
+  processing: Accessor<boolean>
+  progress: Accessor<number>
   onCancel: () => void
   onConfirm: () => void
 }) {
@@ -37,18 +53,20 @@ export function BulkRevealConfirmation({
         'your Humble Bundle account; they will not produce transferable keys.',
       ].join(' ')
 
+  useEscapeKey(onCancel, processing)
+
   return (
     <div
       class={styles.modal_backdrop}
       role="presentation"
-      onMouseDown={(event) => event.target === event.currentTarget && onCancel()}
-      onKeyDown={(event) => event.key === 'Escape' && onCancel()}
+      onMouseDown={(event) => event.target === event.currentTarget && !processing() && onCancel()}
     >
       <section
         class={styles.modal}
         role="dialog"
         aria-modal="true"
         aria-labelledby="hb_extractor-confirm-title"
+        aria-busy={processing()}
         tabindex="-1"
       >
         <header class={styles.modal_header}>
@@ -64,6 +82,7 @@ export function BulkRevealConfirmation({
             aria-label="Cancel"
             title="Cancel"
             onClick={onCancel}
+            disabled={processing()}
           >
             ×
           </button>
@@ -91,6 +110,30 @@ export function BulkRevealConfirmation({
             </div>
           </div>
 
+          <Show when={processing()}>
+            <div class={styles.modal_progress}>
+              <div class={styles.modal_progress_header}>
+                <span>{gift ? 'Creating gift links' : 'Revealing keys'}</span>
+                <strong>
+                  {progress()} of {count}
+                </strong>
+              </div>
+              <div
+                class={styles.modal_progress_track}
+                role="progressbar"
+                aria-label={gift ? 'Gift-link creation progress' : 'Key reveal progress'}
+                aria-valuemin="0"
+                aria-valuemax={count}
+                aria-valuenow={progress()}
+              >
+                <div
+                  class={styles.modal_progress_bar}
+                  style={{ width: `${Math.round((progress() / count) * 100)}%` }}
+                ></div>
+              </div>
+            </div>
+          </Show>
+
           <div class={styles.type_breakdown}>
             <h3>Type breakdown</h3>
             <ul>
@@ -116,15 +159,39 @@ export function BulkRevealConfirmation({
             </div>
           </Show>
 
-          <p class={styles.modal_note}>Nothing will be revealed or exported unless you confirm.</p>
+          <p class={styles.modal_note} aria-live="polite">
+            {processing()
+              ? 'Keep this window open while the reveal and export complete.'
+              : 'Nothing will be revealed or exported unless you confirm.'}
+          </p>
         </div>
 
         <footer class={styles.modal_footer}>
-          <button type="button" class={styles.modal_secondary_button} onClick={onCancel}>
+          <button
+            type="button"
+            class={styles.modal_secondary_button}
+            onClick={onCancel}
+            disabled={processing()}
+          >
             Cancel
           </button>
-          <button type="button" class={styles.modal_primary_button} onClick={onConfirm} autofocus>
-            {gift ? 'Create & Export' : 'Reveal & Export'}
+          <button
+            type="button"
+            class={styles.modal_primary_button}
+            onClick={onConfirm}
+            disabled={processing()}
+            autofocus
+          >
+            {processing() ? (
+              <>
+                <i class="hb hb-spin hb-spinner" aria-hidden="true"></i>{' '}
+                {gift ? 'Creating & Exporting…' : 'Revealing & Exporting…'}
+              </>
+            ) : gift ? (
+              'Create & Export'
+            ) : (
+              'Reveal & Export'
+            )}
           </button>
         </footer>
       </section>
@@ -142,6 +209,8 @@ export function BulkRevealResults({
   const groups = groupClaimResults(report)
   const requested = report.successes.length + report.failures.length
 
+  useEscapeKey(onClose)
+
   const copyLog = (): void => {
     if (copyToClipboard(formatClaimLog(report))) {
       showFlashToast('Log copied to clipboard')
@@ -149,11 +218,7 @@ export function BulkRevealResults({
   }
 
   return (
-    <div
-      class={styles.modal_backdrop}
-      role="presentation"
-      onKeyDown={(event) => event.key === 'Escape' && onClose()}
-    >
+    <div class={styles.modal_backdrop} role="presentation">
       <section
         class={`${styles.modal} ${styles.modal_wide}`}
         role="dialog"

--- a/src/components/BulkRevealDialogs.tsx
+++ b/src/components/BulkRevealDialogs.tsx
@@ -26,6 +26,114 @@ const useEscapeKey = (onEscape: () => void, disabled?: Accessor<boolean>): void 
   onCleanup(() => document.removeEventListener('keydown', handleKeyDown))
 }
 
+export function KeylessRedemptionConfirmation({
+  product,
+  gift,
+  processing,
+  onCancel,
+  onConfirm,
+}: {
+  product: Product
+  gift: boolean
+  processing: Accessor<boolean>
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  const warning = gift
+    ? [
+        'Humble may redeem this item immediately to the third-party account linked to your',
+        'Humble Bundle account instead of producing a transferable gift link.',
+      ].join(' ')
+    : [
+        'Continuing will redeem this item immediately to the third-party account linked to your',
+        'Humble Bundle account. No transferable key will be shown.',
+      ].join(' ')
+
+  useEscapeKey(onCancel, processing)
+
+  return (
+    <div
+      class={styles.modal_backdrop}
+      role="presentation"
+      onMouseDown={(event) => event.target === event.currentTarget && !processing() && onCancel()}
+    >
+      <section
+        class={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="hb_extractor-keyless-confirm-title"
+        aria-busy={processing()}
+        tabindex="-1"
+      >
+        <header class={styles.modal_header}>
+          <div>
+            <p class={styles.modal_eyebrow}>Keyless redemption warning</p>
+            <h2 id="hb_extractor-keyless-confirm-title" class={styles.modal_title}>
+              {gift ? 'Continue with keyless gift-link creation?' : 'Redeem to linked account?'}
+            </h2>
+          </div>
+          <button
+            type="button"
+            class={styles.modal_close}
+            aria-label="Cancel"
+            title="Cancel"
+            onClick={onCancel}
+            disabled={processing()}
+          >
+            ×
+          </button>
+        </header>
+
+        <div class={styles.modal_body}>
+          <p class={styles.modal_lead}>
+            <strong>{product.human_name}</strong> is marked by Humble for direct redemption.
+          </p>
+
+          <div class={styles.modal_warning} role="alert">
+            <strong>Linked-account redemption</strong>
+            <p>{warning} Verify that the correct account is linked before continuing.</p>
+          </div>
+
+          <p class={styles.modal_note} aria-live="polite">
+            {processing()
+              ? 'Keep this window open while Humble processes the request.'
+              : 'Nothing will be redeemed unless you confirm.'}
+          </p>
+        </div>
+
+        <footer class={styles.modal_footer}>
+          <button
+            type="button"
+            class={styles.modal_secondary_button}
+            onClick={onCancel}
+            disabled={processing()}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            class={styles.modal_primary_button}
+            onClick={onConfirm}
+            disabled={processing()}
+            autofocus
+          >
+            {processing() ? (
+              <>
+                <i class="hb hb-spin hb-spinner" aria-hidden="true"></i>{' '}
+                {gift ? 'Continuing…' : 'Redeeming…'}
+              </>
+            ) : gift ? (
+              'Continue'
+            ) : (
+              'Redeem to Linked Account'
+            )}
+          </button>
+        </footer>
+      </section>
+    </div>
+  )
+}
+
 export function BulkRevealConfirmation({
   plan,
   gift,

--- a/src/components/Refresh.tsx
+++ b/src/components/Refresh.tsx
@@ -1,6 +1,6 @@
-export function Refresh({ refresh }: { refresh: () => void }) {
+export function Refresh({ refresh }: { refresh: () => void | Promise<void> }) {
   return (
-    <button type="button" onClick={() => refresh()} title="Reload products">
+    <button type="button" onClick={() => void refresh()} title="Reload products">
       <i class="hb hb-refresh"></i>
     </button>
   )

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -163,18 +163,20 @@ export function Table({
       ].join(' ')
     }
 
-    const localDateKey = (value: unknown): string => {
-      const s = String(value)
-      if (isUtcDateMarker(s)) return s.slice(0, 10)
-
-      const date = parseDate(s)
-      if (!date) return s
-
+    const formatLocalDateKey = (date: Date): string => {
       const year = date.getFullYear()
       const month = String(date.getMonth() + 1).padStart(2, '0')
       const day = String(date.getDate()).padStart(2, '0')
 
       return `${year}-${month}-${day}`
+    }
+
+    const localDateKey = (value: unknown): string => {
+      const s = String(value)
+      if (isUtcDateMarker(s)) return s.slice(0, 10)
+
+      const date = parseDate(s)
+      return date ? formatLocalDateKey(date) : s
     }
 
     const displayDate = (data: unknown, type: string): string => {
@@ -206,6 +208,7 @@ export function Table({
 
     type DateCondition = {
       search?: (value: string, comparison: string[]) => boolean
+      [key: string]: unknown
     }
 
     const dateConditions = (
@@ -261,6 +264,33 @@ export function Table({
       const max = searchDateKey(comparison[1] ?? '')
       return left !== '' && min !== '' && max !== '' && (left < min || left > max)
     })
+
+    const todayDateKey = (): string => formatLocalDateKey(new Date())
+    const isDateKey = (value: string): boolean => /^\d{4}-\d{2}-\d{2}$/.test(value)
+    const expiryDateSearchBuilderType = 'date-expiry'
+    const emptyDateCondition = dateConditions?.null
+    const expiryDateConditions =
+      dateConditions && emptyDateCondition
+        ? {
+            ...dateConditions,
+            expired: {
+              ...emptyDateCondition,
+              conditionName: 'Expired',
+              search: (value: string) => {
+                const date = searchDateKey(value)
+                return isDateKey(date) && date < todayDateKey()
+              },
+            },
+            notExpired: {
+              ...emptyDateCondition,
+              conditionName: 'Not Expired',
+              search: (value: string) => {
+                const date = searchDateKey(value)
+                return date === '' || (isDateKey(date) && date >= todayDateKey())
+              },
+            },
+          }
+        : undefined
 
     let dt!: Api<Product>
 
@@ -546,7 +576,12 @@ export function Table({
                 ]) as unknown as string
               },
             },
-            { title: 'Exp. Date', data: 'expiry_date', type: 'date' },
+            {
+              title: 'Exp. Date',
+              data: 'expiry_date',
+              type: 'date',
+              ...(expiryDateConditions && { searchBuilderType: expiryDateSearchBuilderType }),
+            },
             {
               title: '',
               orderable: false,
@@ -665,6 +700,9 @@ export function Table({
             top1: {
               searchBuilder: {
                 columns: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                ...(expiryDateConditions && {
+                  conditions: { [expiryDateSearchBuilderType]: expiryDateConditions },
+                }),
               },
             },
             bottomEnd: [pageJump, 'paging'],

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,6 +1,14 @@
 import { createSignal, onCleanup, onMount, Show, type Accessor, type Setter } from 'solid-js'
 import { isKeylessProduct } from '../claim-report'
 import { hasRedeemedKeyValue, serializeRedeemedKeyValue } from '../redeemed-key'
+import {
+  getRegionCountryCodes,
+  hasRegionRestrictions,
+  isRegionRedeemableIn,
+  parseRegionRestrictions,
+  serializeRegionRestrictions,
+  type RegionRestrictions,
+} from '../region'
 import { restoreTableState, type TableState } from '../table-state'
 import {
   clearSteamSupportNotice,
@@ -292,6 +300,256 @@ export function Table({
           }
         : undefined
 
+    type SearchBuilderCriteria = {
+      classes: {
+        input: string
+        value: string
+      }
+    }
+    type SearchBuilderValue = {
+      0?: HTMLElement
+      on: (event: string, listener: () => void) => SearchBuilderValue
+      off: (event?: string) => SearchBuilderValue
+      remove: () => void
+    }
+    type SearchBuilderInput = SearchBuilderValue[]
+    type SearchBuilderInputCallback = (criteria: SearchBuilderCriteria, input: unknown) => void
+    type SearchBuilderCondition = {
+      conditionName?: string
+      init?: (
+        criteria: SearchBuilderCriteria,
+        callback: SearchBuilderInputCallback,
+        preDefined?: string[] | null
+      ) => SearchBuilderValue
+      inputValue?: (elements: SearchBuilderInput) => string[]
+      isInputValid?: (elements: SearchBuilderInput) => boolean
+      search?: (value: string, comparison: string[]) => boolean
+      [key: string]: unknown
+    }
+
+    const noValueCondition =
+      (
+        DataTable as typeof DataTable & {
+          ext?: {
+            searchBuilder?: {
+              conditions?: {
+                string?: Record<string, SearchBuilderCondition>
+              }
+            }
+          }
+        }
+      ).ext?.searchBuilder?.conditions?.string?.null ?? emptyDateCondition
+
+    const regionSearchBuilderType = 'region'
+    const countryDisplayNames = new Intl.DisplayNames(undefined, { type: 'region' })
+    const countryOptions = getRegionCountryCodes(products)
+      .map((code) => ({ code, name: countryDisplayNames.of(code) ?? code }))
+      .sort((left, right) => left.name.localeCompare(right.name))
+
+    const getCountrySelect = (elements: SearchBuilderInput): HTMLSelectElement | null => {
+      const element = elements[0]?.[0]
+      return element instanceof HTMLSelectElement ? element : null
+    }
+
+    const createCountryCondition = (
+      conditionName: string,
+      search: (restrictions: RegionRestrictions, countryCode: string) => boolean
+    ): SearchBuilderCondition => ({
+      conditionName,
+      init: (criteria, callback, preDefined = null) => {
+        const select = document.createElement('select')
+        select.classList.add(criteria.classes.value, criteria.classes.input)
+        select.setAttribute('aria-label', 'Country')
+
+        const placeholder = document.createElement('option')
+        placeholder.value = ''
+        placeholder.textContent = 'Country'
+        placeholder.disabled = true
+        placeholder.selected = true
+        select.append(placeholder)
+
+        for (const { code, name } of countryOptions) {
+          const option = document.createElement('option')
+          option.value = code
+          option.textContent = name === code ? code : `${name} (${code})`
+          select.append(option)
+        }
+
+        const selectedCountry = preDefined?.[0]?.trim().toUpperCase() ?? ''
+        if (
+          selectedCountry &&
+          !Array.from(select.options).some((option) => option.value === selectedCountry)
+        ) {
+          const option = document.createElement('option')
+          const name = countryDisplayNames.of(selectedCountry) ?? selectedCountry
+          option.value = selectedCountry
+          option.textContent =
+            name === selectedCountry ? selectedCountry : `${name} (${selectedCountry})`
+          select.append(option)
+        }
+
+        select.value = selectedCountry
+
+        const jquery = DataTable.use('jq') as (element: HTMLElement) => SearchBuilderValue
+        const input = jquery(select)
+        input.on('change.dtsb', () => callback(criteria, select))
+        return input
+      },
+      inputValue: (elements) => [getCountrySelect(elements)?.value ?? ''],
+      isInputValid: (elements) => Boolean(getCountrySelect(elements)?.value),
+      search: (value, comparison) => {
+        const countryCode = comparison[0]
+        return countryCode ? search(parseRegionRestrictions(value), countryCode) : false
+      },
+    })
+
+    const regionConditions = noValueCondition
+      ? {
+          regionRestricted: {
+            ...noValueCondition,
+            conditionName: 'Has restrictions',
+            search: (value: string) => hasRegionRestrictions(parseRegionRestrictions(value)),
+          },
+          regionUnrestricted: {
+            ...noValueCondition,
+            conditionName: 'No restrictions',
+            search: (value: string) => !hasRegionRestrictions(parseRegionRestrictions(value)),
+          },
+          regionRedeemable: createCountryCondition('Redeemable in', isRegionRedeemableIn),
+          regionNotRedeemable: createCountryCondition(
+            'Not redeemable in',
+            (restrictions, countryCode) => !isRegionRedeemableIn(restrictions, countryCode)
+          ),
+        }
+      : undefined
+
+    const countryNames = (codes: string[]): string =>
+      codes
+        .map((code) => countryDisplayNames.of(code) ?? code)
+        .sort((left, right) => left.localeCompare(right))
+        .join(', ')
+
+    const regionHeaderTooltip =
+      'The padlock indicates country restrictions reported by Humble and may not exactly reflect Steam activation restrictions for the assigned key.'
+    const ownedHeaderTooltip =
+      "Relies on the Steam app ID returned by Humble's API and may be inaccurate when keys contain multiple app IDs."
+    const redeemedHeaderTooltip =
+      'Uses Steam Support app ID data, which may be inaccurate when the key contains multiple app IDs.'
+    const redeemedDataCaveat =
+      "Uses Steam Support app ID data, which may be inaccurate when the key's package (sub ID) contains multiple app IDs."
+
+    const regionTooltip = (row: Product): string => {
+      const exclusive = row.exclusive_countries
+      const disallowed = row.disallowed_countries
+      const details: string[] = []
+
+      if (exclusive.length) {
+        details.push(`Redeemable only in: ${countryNames(exclusive)}.`)
+      }
+      if (disallowed.length) {
+        details.push(`Unavailable in: ${countryNames(disallowed)}.`)
+      }
+      if (!details.length) details.push('No region restrictions reported by Humble.')
+
+      return details.join('\n')
+    }
+
+    const regionPopover = document.createElement('div')
+    regionPopover.className = styles.region_tooltip
+    regionPopover.role = 'tooltip'
+    regionPopover.hidden = true
+    document.body.append(regionPopover)
+
+    const regionPopoverShowDelay = 500
+    const regionPopoverHideDelay = 120
+    let regionPopoverAnchor: HTMLElement | null = null
+    let regionPopoverShowTimer: number | null = null
+    let regionPopoverHideTimer: number | null = null
+
+    const cancelRegionPopoverShow = (): void => {
+      if (regionPopoverShowTimer == null) return
+      window.clearTimeout(regionPopoverShowTimer)
+      regionPopoverShowTimer = null
+    }
+
+    const cancelRegionPopoverHide = (): void => {
+      if (regionPopoverHideTimer == null) return
+      window.clearTimeout(regionPopoverHideTimer)
+      regionPopoverHideTimer = null
+    }
+
+    const hideRegionPopover = (force = false): void => {
+      cancelRegionPopoverShow()
+      cancelRegionPopoverHide()
+
+      if (
+        !force &&
+        (regionPopoverAnchor?.matches(':hover, :focus') || regionPopover.matches(':hover'))
+      ) {
+        return
+      }
+
+      regionPopover.hidden = true
+      regionPopoverAnchor = null
+    }
+
+    const scheduleRegionPopoverHide = (): void => {
+      cancelRegionPopoverShow()
+      cancelRegionPopoverHide()
+      regionPopoverHideTimer = window.setTimeout(() => hideRegionPopover(), regionPopoverHideDelay)
+    }
+
+    const positionRegionPopover = (anchor: HTMLElement): void => {
+      const anchorRect = anchor.getBoundingClientRect()
+      const tooltipRect = regionPopover.getBoundingClientRect()
+      const margin = 8
+      const gap = 6
+      const centeredLeft = anchorRect.left + anchorRect.width / 2 - tooltipRect.width / 2
+      const left = Math.min(
+        Math.max(margin, centeredLeft),
+        Math.max(margin, window.innerWidth - tooltipRect.width - margin)
+      )
+      const below = anchorRect.bottom + gap
+      const top =
+        below + tooltipRect.height <= window.innerHeight - margin
+          ? below
+          : Math.max(margin, anchorRect.top - tooltipRect.height - gap)
+
+      regionPopover.style.left = `${Math.round(left)}px`
+      regionPopover.style.top = `${Math.round(top)}px`
+    }
+
+    const showRegionPopover = (anchor: HTMLElement, text: string): void => {
+      cancelRegionPopoverShow()
+      cancelRegionPopoverHide()
+      regionPopoverAnchor = anchor
+      regionPopover.textContent = text
+      regionPopover.hidden = false
+      positionRegionPopover(anchor)
+    }
+
+    const scheduleRegionPopoverShow = (anchor: HTMLElement, text: string): void => {
+      cancelRegionPopoverShow()
+      cancelRegionPopoverHide()
+
+      if (!regionPopover.hidden) {
+        showRegionPopover(anchor, text)
+        return
+      }
+
+      regionPopoverShowTimer = window.setTimeout(() => {
+        regionPopoverShowTimer = null
+        if (anchor.matches(':hover')) showRegionPopover(anchor, text)
+      }, regionPopoverShowDelay)
+    }
+
+    regionPopover.addEventListener('mouseenter', cancelRegionPopoverHide)
+    regionPopover.addEventListener('mouseleave', scheduleRegionPopoverHide)
+
+    const closeRegionPopover = (): void => hideRegionPopover(true)
+    window.addEventListener('resize', closeRegionPopover)
+    window.addEventListener('scroll', closeRegionPopover, true)
+
     let dt!: Api<Product>
 
     const pageJumpInput = document.createElement('input')
@@ -396,7 +654,7 @@ export function Table({
               render: displayDate,
             },
             {
-              targets: [10],
+              targets: [11],
               data: null,
               defaultContent: '',
             },
@@ -404,14 +662,17 @@ export function Table({
           order: [[7, 'desc']],
           columns: [
             {
-              title: 'Type',
+              title: `Type<span class="${styles.header_note}" title="${regionHeaderTooltip}"></span>`,
               data: 'key_type',
               type: 'html-utf8',
+              searchBuilder: {
+                orthogonal: { display: 'filter' },
+              },
               render: (data, type, row) => {
                 const value = renderCellValue(data, type)
                 if (value !== undefined) return value
 
-                return hm(
+                const platformIcon = hm(
                   'i',
                   {
                     class: `hb hb-key hb-${data}`,
@@ -419,6 +680,30 @@ export function Table({
                   },
                   hm('span', { class: 'hidden', innerText: String(data) })
                 )
+
+                if (!hasRegionRestrictions(row)) return platformIcon
+
+                const tooltip = regionTooltip(row)
+                return hm('span', { class: styles.platform_icon }, [
+                  platformIcon,
+                  hm('span', {
+                    class: styles.region_lock,
+                    tabindex: 0,
+                    'aria-label': tooltip,
+                    innerText: '🔒',
+                    onmouseenter: (event: MouseEvent) =>
+                      scheduleRegionPopoverShow(event.currentTarget as HTMLElement, tooltip),
+                    onmouseleave: scheduleRegionPopoverHide,
+                    onfocus: (event: FocusEvent) =>
+                      showRegionPopover(event.currentTarget as HTMLElement, tooltip),
+                    onblur: scheduleRegionPopoverHide,
+                    onkeydown: (event: KeyboardEvent) => {
+                      if (event.key !== 'Escape') return
+                      hideRegionPopover(true)
+                      ;(event.currentTarget as HTMLElement).blur()
+                    },
+                  }),
+                ]) as unknown as string
               },
               className: styles.platform,
             },
@@ -469,7 +754,7 @@ export function Table({
               render: (data, type) => displayYesNoBadge(data, type, styles.warning_badge),
             },
             {
-              title: `Owned <span class="${styles.header_note}" title="Relies on the Steam app ID returned by Humble's API and may be inaccurate for package/sub keys."></span>`,
+              title: `Owned<span class="${styles.header_note}" title="${ownedHeaderTooltip}"></span>`,
               data: 'owned',
               type: 'string-utf8',
               render: displayOwned,
@@ -479,7 +764,7 @@ export function Table({
               // ---------------------------------------------------------------
               // "Redeemed" column — Steam Support app-level data
               // ---------------------------------------------------------------
-              title: `Redeemed <span class="${styles.header_note}" title="Uses Steam Support app ID data and may be inaccurate for package/sub keys."></span>`,
+              title: `Redeemed<span class="${styles.header_note}" title="${redeemedHeaderTooltip}"></span>`,
               data: null,
               type: 'date',
               className: 'dt-right',
@@ -581,6 +866,19 @@ export function Table({
               data: 'expiry_date',
               type: 'date',
               ...(expiryDateConditions && { searchBuilderType: expiryDateSearchBuilderType }),
+            },
+            {
+              title: 'Region',
+              data: 'exclusive_countries',
+              type: 'string-utf8',
+              render: (_data, _type, row) => serializeRegionRestrictions(row),
+              visible: false,
+              orderable: false,
+              searchable: false,
+              searchBuilder: {
+                orthogonal: { display: 'region', search: 'region' },
+              },
+              ...(regionConditions && { searchBuilderType: regionSearchBuilderType }),
             },
             {
               title: '',
@@ -699,10 +997,13 @@ export function Table({
           layout: {
             top1: {
               searchBuilder: {
-                columns: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-                ...(expiryDateConditions && {
-                  conditions: { [expiryDateSearchBuilderType]: expiryDateConditions },
-                }),
+                columns: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                conditions: {
+                  ...(expiryDateConditions && {
+                    [expiryDateSearchBuilderType]: expiryDateConditions,
+                  }),
+                  ...(regionConditions && { [regionSearchBuilderType]: regionConditions }),
+                },
               },
             },
             bottomEnd: [pageJump, 'paging'],
@@ -755,6 +1056,7 @@ export function Table({
     dt.on('page', rememberPagingTop)
     dt.on('draw', restorePagingTop)
     dt.on('draw', syncPageJump)
+    dt.on('draw', closeRegionPopover)
 
     // Warnings when selecting certain column filters
 
@@ -785,10 +1087,14 @@ export function Table({
         show: (selectedColumns) => selectedColumns.includes('Owned'),
       },
       {
-        element: makeWarning(
-          '⚠️ "Redeemed" column uses Steam Support app ID data, which may be inaccurate when the key\'s package (sub ID) contains more than one app ID.'
-        ),
+        element: makeWarning(`⚠️ "Redeemed" column: ${redeemedDataCaveat}`),
         show: (selectedColumns) => selectedColumns.includes('Redeemed'),
+      },
+      {
+        element: makeWarning(
+          '⚠️ "Region" uses country restriction data reported by Humble and may not exactly reflect Steam activation restrictions for the assigned key.'
+        ),
+        show: (selectedColumns) => selectedColumns.includes('Region'),
       },
     ]
 
@@ -821,6 +1127,15 @@ export function Table({
       dt.off('page', rememberPagingTop)
       dt.off('draw', restorePagingTop)
       dt.off('draw', syncPageJump)
+      dt.off('draw', closeRegionPopover)
+
+      window.removeEventListener('resize', closeRegionPopover)
+      window.removeEventListener('scroll', closeRegionPopover, true)
+      regionPopover.removeEventListener('mouseenter', cancelRegionPopoverHide)
+      regionPopover.removeEventListener('mouseleave', scheduleRegionPopoverHide)
+      cancelRegionPopoverShow()
+      cancelRegionPopoverHide()
+      regionPopover.remove()
 
       searchBuilderRoot?.removeEventListener('change', refreshWarnings)
       observer?.disconnect()

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,6 +1,9 @@
 import { onCleanup, onMount, type Accessor, type Setter } from 'solid-js'
+import { hasRedeemedKeyValue, serializeRedeemedKeyValue } from '../redeemed-key'
+import { restoreTableState, type TableState } from '../table-state'
 import {
   clearSteamSupportNotice,
+  copyToClipboard,
   redeem,
   fetchRedeemedDate,
   setRedeemedDate,
@@ -18,10 +21,14 @@ export function Table({
   products,
   steamId,
   setDt,
+  initialState,
+  onStateRestored,
 }: {
   products: Product[]
   steamId: Accessor<string | null>
-  setDt: Setter<Api<Product>>
+  setDt: Setter<Api<Product> | null>
+  initialState?: TableState | null
+  onStateRestored?: () => void
 }) {
   let tableRef!: HTMLTableElement
 
@@ -147,6 +154,9 @@ export function Table({
     /** Steam Support URL for a given appId */
     const steamSupportUrl = (appId: number) =>
       `https://help.steampowered.com/en/wizard/HelpWithGame?appid=${appId}`
+
+    const steamRegistrationUrl = (key: string): string =>
+      `https://store.steampowered.com/account/registerkey?key=${encodeURIComponent(key)}`
 
     const searchDateKey = (value: string): string => {
       const s = value.trim()
@@ -296,7 +306,8 @@ export function Table({
             },
             {
               title: 'Revealed',
-              data: (row: Product) => (row.is_gift || row.redeemed_key_val ? 'Yes' : 'No'),
+              data: (row: Product) =>
+                row.is_gift || hasRedeemedKeyValue(row.redeemed_key_val) ? 'Yes' : 'No',
               type: 'string-utf8',
               render: (data, type) => displayYesNoBadge(data, type, styles.warning_badge),
             },
@@ -416,7 +427,7 @@ export function Table({
               data: (row: Product) => {
                 const actions = []
 
-                if (row.redeemed_key_val) {
+                if (hasRedeemedKeyValue(row.redeemed_key_val)) {
                   actions.push(
                     hm(
                       'button',
@@ -425,8 +436,9 @@ export function Table({
                         title: 'Copy to clipboard',
                         type: 'button',
                         onclick: () => {
-                          navigator.clipboard.writeText(row.redeemed_key_val)
-                          showFlashToast('Copied to clipboard')
+                          if (copyToClipboard(serializeRedeemedKeyValue(row.redeemed_key_val))) {
+                            showFlashToast('Copied to clipboard')
+                          }
                         },
                       },
                       hm('i', { class: 'hb hb-key hb-clipboard' })
@@ -434,13 +446,18 @@ export function Table({
                   )
                 }
 
-                if (row.redeemed_key_val && !row.is_gift && row.key_type === 'steam') {
+                if (
+                  typeof row.redeemed_key_val === 'string' &&
+                  row.redeemed_key_val &&
+                  !row.is_gift &&
+                  row.key_type === 'steam'
+                ) {
                   actions.push(
                     hm(
                       'a',
                       {
                         class: styles.btn,
-                        href: `https://store.steampowered.com/account/registerkey?key=${row.redeemed_key_val}`,
+                        href: steamRegistrationUrl(row.redeemed_key_val),
                         target: '_blank',
                       },
                       hm('i', { class: 'hb hb-shopping-cart-light', title: 'Redeem' })
@@ -448,7 +465,12 @@ export function Table({
                   )
                 }
 
-                if (row.redeemed_key_val && row.is_gift && !row.is_expired) {
+                if (
+                  typeof row.redeemed_key_val === 'string' &&
+                  row.redeemed_key_val &&
+                  row.is_gift &&
+                  !row.is_expired
+                ) {
                   actions.push(
                     hm(
                       'a',
@@ -462,7 +484,7 @@ export function Table({
                   )
                 }
 
-                if (!row.redeemed_key_val && !row.is_gift && !row.is_expired) {
+                if (!hasRedeemedKeyValue(row.redeemed_key_val) && !row.is_gift && !row.is_expired) {
                   actions.push(
                     hm(
                       'button',
@@ -472,8 +494,14 @@ export function Table({
                         onclick: async () => {
                           try {
                             const key = await redeem(row)
-                            await navigator.clipboard.writeText(key)
-                            showFlashToast('Key copied to clipboard')
+                            row.redeemed_key_val = key
+                            row.type = 'Key'
+                            dt.rows((_index, product) => product === row)
+                              .invalidate('data')
+                              .draw(false)
+                            if (copyToClipboard(serializeRedeemedKeyValue(key))) {
+                              showFlashToast('Key copied to clipboard')
+                            }
                           } catch (error) {
                             showErrorToast(error)
                           }
@@ -489,8 +517,15 @@ export function Table({
                         onclick: async () => {
                           try {
                             const link = await redeem(row, true)
-                            await navigator.clipboard.writeText(link)
-                            showFlashToast('Link copied to clipboard')
+                            row.redeemed_key_val = link
+                            row.type = 'Gift'
+                            row.is_gift = true
+                            dt.rows((_index, product) => product === row)
+                              .invalidate('data')
+                              .draw(false)
+                            if (copyToClipboard(serializeRedeemedKeyValue(link))) {
+                              showFlashToast('Link copied to clipboard')
+                            }
                           } catch (error) {
                             showErrorToast(error)
                           }
@@ -520,6 +555,16 @@ export function Table({
           },
         }))
     )
+
+    if (initialState) {
+      try {
+        restoreTableState(dt, initialState)
+      } catch (error) {
+        showErrorToast(error, 'Failed to restore table filters')
+      } finally {
+        onStateRestored?.()
+      }
+    }
 
     const container = dt.table().container() as HTMLElement
 
@@ -620,6 +665,7 @@ export function Table({
       for (const warning of warnings) warning.element.remove()
 
       dt.destroy()
+      setDt((current) => (current === dt ? null : current))
     })
   })
   console.debug('Table Loaded')

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -269,7 +269,7 @@ export function Table({
       if (keyless && !(await requestKeylessConfirmation(row, gift))) return
 
       try {
-        if (hasRedeemedKeyValue(row.redeemed_key_val) || row.is_gift || row.is_expired) return
+        if (hasRedeemedKeyValue(row.redeemed_key_val) || row.is_gift) return
 
         const value = await redeem(row, gift)
         row.redeemed_key_val = value
@@ -558,7 +558,22 @@ export function Table({
                   )
                 }
 
-                if (!hasRedeemedKeyValue(row.redeemed_key_val) && !row.is_gift && !row.is_expired) {
+                if (!hasRedeemedKeyValue(row.redeemed_key_val) && !row.is_gift) {
+                  const revealTitle = keyless
+                    ? row.is_expired
+                      ? 'Attempt direct redemption to the linked account (marked expired); no transferable key will be shown'
+                      : 'Redeem directly to the linked account; no transferable key will be shown'
+                    : row.is_expired
+                      ? 'Attempt reveal (marked expired)'
+                      : 'Reveal'
+                  const giftTitle = keyless
+                    ? row.is_expired
+                      ? 'Attempt gift-link creation (marked expired); Humble may redeem this directly to the linked account'
+                      : 'Create gift link; Humble may redeem this directly to the linked account'
+                    : row.is_expired
+                      ? 'Attempt gift-link creation (marked expired)'
+                      : 'Create gift link'
+
                   actions.push(
                     hm(
                       'button',
@@ -569,9 +584,7 @@ export function Table({
                       },
                       hm('i', {
                         class: keyless ? 'hb hb-link' : 'hb hb-magic',
-                        title: keyless
-                          ? 'Redeem directly to the linked account; no transferable key will be shown'
-                          : 'Reveal',
+                        title: revealTitle,
                       })
                     ),
                     hm(
@@ -583,9 +596,7 @@ export function Table({
                       },
                       hm('i', {
                         class: 'hb hb-gift',
-                        title: keyless
-                          ? 'Create gift link; Humble may redeem this directly to the linked account'
-                          : 'Create gift link',
+                        title: giftTitle,
                       })
                     )
                   )

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -264,6 +264,60 @@ export function Table({
 
     let dt!: Api<Product>
 
+    const pageJumpInput = document.createElement('input')
+    pageJumpInput.className = styles.page_jump_input
+    pageJumpInput.type = 'text'
+    pageJumpInput.inputMode = 'numeric'
+    pageJumpInput.pattern = '[0-9]*'
+    pageJumpInput.autocomplete = 'off'
+    pageJumpInput.enterKeyHint = 'go'
+    pageJumpInput.setAttribute('aria-label', 'Jump to page')
+    pageJumpInput.title = 'Enter a page number and press Enter'
+
+    const pageJumpTotal = document.createElement('span')
+    const pageJump = document.createElement('label')
+    pageJump.className = styles.page_jump
+    pageJump.append('Jump to', pageJumpInput, 'of', pageJumpTotal)
+
+    const syncPageJump = (): void => {
+      const info = dt.page.info()
+      const hasPages = info.pages > 0
+
+      pageJumpInput.disabled = !hasPages
+      pageJumpInput.value = hasPages ? String(info.page + 1) : ''
+      pageJumpInput.maxLength = Math.max(1, String(info.pages).length)
+      pageJumpInput.style.width = `${Math.max(4, String(info.pages).length + 2)}ch`
+      pageJumpTotal.textContent = String(info.pages)
+    }
+
+    const jumpToPage = (): void => {
+      const info = dt.page.info()
+      const requestedPage = Number(pageJumpInput.value)
+
+      if (!Number.isInteger(requestedPage) || requestedPage < 1 || info.pages === 0) {
+        syncPageJump()
+        return
+      }
+
+      const page = Math.min(requestedPage, info.pages) - 1
+      pageJumpInput.value = String(page + 1)
+
+      if (page !== info.page) dt.page(page).draw('page')
+    }
+
+    pageJumpInput.addEventListener('focus', () => pageJumpInput.select())
+    pageJumpInput.addEventListener('change', jumpToPage)
+    pageJumpInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        jumpToPage()
+      } else if (event.key === 'Escape') {
+        event.preventDefault()
+        syncPageJump()
+        pageJumpInput.blur()
+      }
+    })
+
     const revealProduct = async (row: Product, gift: boolean): Promise<void> => {
       const keyless = isKeylessProduct(row)
       if (keyless && !(await requestKeylessConfirmation(row, gift))) return
@@ -613,6 +667,7 @@ export function Table({
                 columns: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
               },
             },
+            bottomEnd: [pageJump, 'paging'],
           },
           createdRow: function (row, data: Product) {
             if (data.is_expired) {
@@ -658,8 +713,10 @@ export function Table({
       })
     }
 
+    syncPageJump()
     dt.on('page', rememberPagingTop)
     dt.on('draw', restorePagingTop)
+    dt.on('draw', syncPageJump)
 
     // Warnings when selecting certain column filters
 
@@ -725,6 +782,7 @@ export function Table({
     onCleanup(() => {
       dt.off('page', rememberPagingTop)
       dt.off('draw', restorePagingTop)
+      dt.off('draw', syncPageJump)
 
       searchBuilderRoot?.removeEventListener('change', refreshWarnings)
       observer?.disconnect()

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,4 +1,5 @@
-import { onCleanup, onMount, type Accessor, type Setter } from 'solid-js'
+import { createSignal, onCleanup, onMount, Show, type Accessor, type Setter } from 'solid-js'
+import { isKeylessProduct } from '../claim-report'
 import { hasRedeemedKeyValue, serializeRedeemedKeyValue } from '../redeemed-key'
 import { restoreTableState, type TableState } from '../table-state'
 import {
@@ -16,6 +17,13 @@ import DataTable, { type Api } from 'datatables.net-dt'
 import { hm } from '@violentmonkey/dom'
 // @ts-expect-error missing types
 import styles from '../style.module.css'
+import { KeylessRedemptionConfirmation } from './BulkRevealDialogs'
+
+type PendingKeylessRedemption = {
+  product: Product
+  gift: boolean
+  resolve: (confirmed: boolean) => void
+}
 
 export function Table({
   products,
@@ -31,6 +39,36 @@ export function Table({
   onStateRestored?: () => void
 }) {
   let tableRef!: HTMLTableElement
+  const [pendingKeylessRedemption, setPendingKeylessRedemption] =
+    createSignal<PendingKeylessRedemption | null>(null)
+  const [keylessRedemptionProcessing, setKeylessRedemptionProcessing] = createSignal(false)
+
+  const requestKeylessConfirmation = (product: Product, gift: boolean): Promise<boolean> => {
+    if (pendingKeylessRedemption()) return Promise.resolve(false)
+
+    setKeylessRedemptionProcessing(false)
+    return new Promise((resolve) => setPendingKeylessRedemption({ product, gift, resolve }))
+  }
+
+  const cancelKeylessRedemption = (): void => {
+    if (keylessRedemptionProcessing()) return
+
+    const pending = pendingKeylessRedemption()
+    if (!pending) return
+
+    setPendingKeylessRedemption(null)
+    pending.resolve(false)
+  }
+
+  const confirmKeylessRedemption = (): void => {
+    const pending = pendingKeylessRedemption()
+    if (!pending || keylessRedemptionProcessing()) return
+
+    setKeylessRedemptionProcessing(true)
+    pending.resolve(true)
+  }
+
+  onCleanup(() => pendingKeylessRedemption()?.resolve(false))
 
   onMount(() => {
     console.debug('Mounting table with', products.length, 'products')
@@ -225,6 +263,41 @@ export function Table({
     })
 
     let dt!: Api<Product>
+
+    const revealProduct = async (row: Product, gift: boolean): Promise<void> => {
+      const keyless = isKeylessProduct(row)
+      if (keyless && !(await requestKeylessConfirmation(row, gift))) return
+
+      try {
+        if (hasRedeemedKeyValue(row.redeemed_key_val) || row.is_gift || row.is_expired) return
+
+        const value = await redeem(row, gift)
+        row.redeemed_key_val = value
+        row.type = gift ? 'Gift' : 'Key'
+        row.is_gift = gift
+        dt.rows((_index, product) => product === row)
+          .invalidate('data')
+          .draw(false)
+
+        if (copyToClipboard(serializeRedeemedKeyValue(value))) {
+          showFlashToast(
+            keyless
+              ? 'Redemption result copied to clipboard'
+              : gift
+                ? 'Link copied to clipboard'
+                : 'Key copied to clipboard'
+          )
+        }
+      } catch (error) {
+        showErrorToast(error)
+      } finally {
+        if (keyless) {
+          setPendingKeylessRedemption(null)
+          setKeylessRedemptionProcessing(false)
+        }
+      }
+    }
+
     setDt(
       () =>
         (dt = new DataTable<Product>(tableRef, {
@@ -426,6 +499,7 @@ export function Table({
               searchable: false,
               data: (row: Product) => {
                 const actions = []
+                const keyless = isKeylessProduct(row)
 
                 if (hasRedeemedKeyValue(row.redeemed_key_val)) {
                   actions.push(
@@ -491,47 +565,28 @@ export function Table({
                       {
                         class: styles.btn,
                         type: 'button',
-                        onclick: async () => {
-                          try {
-                            const key = await redeem(row)
-                            row.redeemed_key_val = key
-                            row.type = 'Key'
-                            dt.rows((_index, product) => product === row)
-                              .invalidate('data')
-                              .draw(false)
-                            if (copyToClipboard(serializeRedeemedKeyValue(key))) {
-                              showFlashToast('Key copied to clipboard')
-                            }
-                          } catch (error) {
-                            showErrorToast(error)
-                          }
-                        },
+                        onclick: () => void revealProduct(row, false),
                       },
-                      hm('i', { class: 'hb hb-magic', title: 'Reveal' })
+                      hm('i', {
+                        class: keyless ? 'hb hb-link' : 'hb hb-magic',
+                        title: keyless
+                          ? 'Redeem directly to the linked account; no transferable key will be shown'
+                          : 'Reveal',
+                      })
                     ),
                     hm(
                       'button',
                       {
                         class: styles.btn,
                         type: 'button',
-                        onclick: async () => {
-                          try {
-                            const link = await redeem(row, true)
-                            row.redeemed_key_val = link
-                            row.type = 'Gift'
-                            row.is_gift = true
-                            dt.rows((_index, product) => product === row)
-                              .invalidate('data')
-                              .draw(false)
-                            if (copyToClipboard(serializeRedeemedKeyValue(link))) {
-                              showFlashToast('Link copied to clipboard')
-                            }
-                          } catch (error) {
-                            showErrorToast(error)
-                          }
-                        },
+                        onclick: () => void revealProduct(row, true),
                       },
-                      hm('i', { class: 'hb hb-gift', title: 'Create gift link' })
+                      hm('i', {
+                        class: 'hb hb-gift',
+                        title: keyless
+                          ? 'Create gift link; Humble may redeem this directly to the linked account'
+                          : 'Create gift link',
+                      })
                     )
                   )
                 }
@@ -669,5 +724,20 @@ export function Table({
     })
   })
   console.debug('Table Loaded')
-  return <table ref={tableRef} id="hb_extractor-table" class="display compact"></table>
+  return (
+    <>
+      <table ref={tableRef} id="hb_extractor-table" class="display compact"></table>
+      <Show when={pendingKeylessRedemption()} keyed>
+        {(pending) => (
+          <KeylessRedemptionConfirmation
+            product={pending.product}
+            gift={pending.gift}
+            processing={keylessRedemptionProcessing}
+            onCancel={cancelKeylessRedemption}
+            onConfirm={confirmKeylessRedemption}
+          />
+        )}
+      </Show>
+    </>
+  )
 }

--- a/src/concurrency.ts
+++ b/src/concurrency.ts
@@ -1,0 +1,20 @@
+export const forEachConcurrent = async <T>(
+  items: readonly T[],
+  concurrency: number,
+  callback: (item: T, index: number) => Promise<void>
+): Promise<void> => {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new RangeError('Concurrency must be a positive integer')
+  }
+
+  let nextIndex = 0
+
+  const worker = async (): Promise<void> => {
+    while (nextIndex < items.length) {
+      const index = nextIndex++
+      await callback(items[index], index)
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()))
+}

--- a/src/meta.js
+++ b/src/meta.js
@@ -16,6 +16,7 @@
 // @homepageURL https://github.com/MrMarble/hb-key-exporter
 // @grant       GM_addStyle
 // @grant       GM_getResourceText
+// @grant       GM_setClipboard
 // @grant       GM_xmlhttpRequest
 // @connect     store.steampowered.com
 // @connect     help.steampowered.com

--- a/src/redeemed-key.ts
+++ b/src/redeemed-key.ts
@@ -1,0 +1,11 @@
+export type RedeemedKeyValue = string | Record<string, unknown>
+
+export const hasRedeemedKeyValue = (value: unknown): value is RedeemedKeyValue =>
+  typeof value === 'string'
+    ? value.length > 0
+    : value !== null && typeof value === 'object' && !Array.isArray(value)
+
+export const serializeRedeemedKeyValue = (value: unknown): string => {
+  if (!hasRedeemedKeyValue(value)) return ''
+  return typeof value === 'string' ? value : (JSON.stringify(value) ?? '')
+}

--- a/src/region.ts
+++ b/src/region.ts
@@ -1,0 +1,55 @@
+export interface RegionRestrictions {
+  exclusive_countries: string[]
+  disallowed_countries: string[]
+}
+
+const ISO_COUNTRY_CODES =
+  'AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BV BW BY BZ CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ VA VC VE VG VI VN VU WF WS XK YE YT ZA ZM ZW'.split(
+    ' '
+  )
+
+const normalizeCountryCode = (code: string): string => code.trim().toUpperCase()
+
+export const normalizeCountryCodes = (codes?: readonly string[]): string[] =>
+  Array.from(
+    new Set((codes ?? []).map(normalizeCountryCode).filter((code) => /^[A-Z]{2}$/.test(code)))
+  ).sort()
+
+export const hasRegionRestrictions = (restrictions: RegionRestrictions): boolean =>
+  restrictions.exclusive_countries.length > 0 || restrictions.disallowed_countries.length > 0
+
+export const isRegionRedeemableIn = (
+  restrictions: RegionRestrictions,
+  countryCode: string
+): boolean => {
+  const country = normalizeCountryCode(countryCode)
+  if (!/^[A-Z]{2}$/.test(country)) return false
+
+  const exclusive = restrictions.exclusive_countries
+  const disallowed = restrictions.disallowed_countries
+
+  return (!exclusive.length || exclusive.includes(country)) && !disallowed.includes(country)
+}
+
+export const serializeRegionRestrictions = (restrictions: RegionRestrictions): string =>
+  `${restrictions.exclusive_countries.join(',')}|${restrictions.disallowed_countries.join(',')}`
+
+export const parseRegionRestrictions = (value: string): RegionRestrictions => {
+  const [exclusive = '', disallowed = ''] = value.split('|', 2)
+
+  return {
+    exclusive_countries: exclusive ? exclusive.split(',') : [],
+    disallowed_countries: disallowed ? disallowed.split(',') : [],
+  }
+}
+
+export const getRegionCountryCodes = (restrictions: RegionRestrictions[]): string[] =>
+  Array.from(
+    new Set([
+      ...ISO_COUNTRY_CODES,
+      ...restrictions.flatMap(({ exclusive_countries, disallowed_countries }) => [
+        ...exclusive_countries,
+        ...disallowed_countries,
+      ]),
+    ])
+  ).sort()

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -75,10 +75,20 @@ tr.expired {
 
 .page_jump {
   display: inline-flex;
+  flex: 0 0 auto;
   align-items: center;
   gap: 5px;
   margin-inline-end: 8px;
   white-space: nowrap;
+}
+
+:global(.dt-layout-end):has(> .page_jump) {
+  flex-wrap: wrap;
+  row-gap: 0.5em;
+}
+
+.page_jump + :global(.dt-paging) {
+  flex: 0 0 auto;
 }
 
 .page_jump_input {

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -11,11 +11,11 @@ tr.expired {
 }
 
 .header_note {
-  margin-left: 3px;
+  margin-left: 1px;
   color: #2f6f9f;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 700;
-  vertical-align: 1px;
+  vertical-align: baseline;
   cursor: help;
 }
 
@@ -101,6 +101,46 @@ tr.expired {
   border-radius: 3px;
   font: inherit;
   text-align: center;
+}
+
+.platform_icon {
+  position: relative;
+  display: inline-block;
+  line-height: 1;
+}
+
+.region_lock {
+  position: absolute;
+  right: -0.55em;
+  bottom: -0.25em;
+  font-size: 11px;
+  line-height: 1;
+  cursor: help;
+}
+
+.region_lock:focus-visible {
+  outline: 1px solid currentColor;
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.region_tooltip {
+  position: fixed;
+  z-index: 10000;
+  box-sizing: border-box;
+  width: max-content;
+  max-width: min(360px, calc(100vw - 16px));
+  padding: 7px 9px;
+  background: #222;
+  color: #fff;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.28);
+  font-size: 12px;
+  line-height: 1.4;
+  text-align: left;
+  white-space: pre-line;
+  cursor: text;
+  user-select: text;
 }
 
 .yes_no_badge {

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -44,6 +44,17 @@ tr.expired {
   margin-bottom: 10px;
 }
 
+.checkbox_label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.checkbox_label input[type='checkbox'] {
+  margin: 0;
+  transform: translateY(0.25px);
+}
+
 .btn {
   background-color: #e9e9ed;
   border: 1px solid #8f8f9d;
@@ -101,8 +112,8 @@ tr.expired {
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: rgba(18, 22, 29, 0.68);
-  backdrop-filter: blur(2px);
+  background: rgba(18, 22, 29, 0.72);
+  backdrop-filter: brightness(0.65) saturate(0.65);
 }
 
 .modal {
@@ -211,6 +222,33 @@ tr.expired {
   color: #69717d;
   font-size: 12px;
   font-weight: 600;
+}
+
+.modal_progress {
+  margin-bottom: 18px;
+}
+
+.modal_progress_header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 7px;
+  color: #404650;
+  font-size: 12.5px;
+}
+
+.modal_progress_track {
+  height: 8px;
+  overflow: hidden;
+  background: #e1e4e8;
+  border-radius: 999px;
+}
+
+.modal_progress_bar {
+  height: 100%;
+  background: #f4511e;
+  border-radius: inherit;
+  transition: width 180ms ease-out;
 }
 
 .type_breakdown {

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -73,6 +73,26 @@ tr.expired {
   align-items: center;
 }
 
+.page_jump {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-inline-end: 8px;
+  white-space: nowrap;
+}
+
+.page_jump_input {
+  box-sizing: border-box;
+  min-width: 4ch;
+  padding: 0.5em 0.6em;
+  background: #fff;
+  color: #000;
+  border: 1px solid #aaa;
+  border-radius: 3px;
+  font: inherit;
+  text-align: center;
+}
+
 .yes_no_badge {
   display: inline-block;
   min-width: 3ch;

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -383,6 +383,29 @@ tr.expired {
   border-color: #efc2c8;
 }
 
+.result_group_controls {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.result_group_button {
+  padding: 4px 8px;
+  background: #fff;
+  color: #3d434c;
+  border: 1px solid #b8bec7;
+  border-radius: 5px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.result_group_button:hover,
+.result_group_button:focus-visible {
+  background: #eef0f3;
+}
+
 .result_groups {
   display: flex;
   flex-direction: column;
@@ -467,6 +490,17 @@ tr.expired {
   margin-top: 2px;
   color: #626a75;
   line-height: 1.35;
+}
+
+.result_type {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.result_type_icon {
+  font-size: 13px;
+  line-height: 1;
 }
 
 .result_success {

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -92,3 +92,387 @@ tr.expired {
   background-color: #fff3cd;
   color: #664d03;
 }
+
+.modal_backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(18, 22, 29, 0.68);
+  backdrop-filter: blur(2px);
+}
+
+.modal {
+  display: flex;
+  width: min(560px, 100%);
+  max-height: min(86vh, 760px);
+  flex-direction: column;
+  overflow: hidden;
+  background: #fff;
+  color: #252a32;
+  border: 1px solid #c9ced6;
+  border-radius: 10px;
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.38);
+}
+
+.modal_wide {
+  width: min(760px, 100%);
+}
+
+.modal_header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 20px 22px 16px;
+  border-bottom: 1px solid #e1e4e8;
+}
+
+.modal_eyebrow {
+  margin: 0 0 4px;
+  color: #69717d;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.modal_title {
+  margin: 0;
+  color: #252a32;
+  font-size: 22px;
+  line-height: 1.2;
+}
+
+.modal_close {
+  flex: 0 0 auto;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: transparent;
+  color: #626a75;
+  border: 0;
+  border-radius: 5px;
+  font-size: 24px;
+  line-height: 28px;
+  cursor: pointer;
+}
+
+.modal_close:hover,
+.modal_close:focus-visible {
+  background: #eef0f3;
+  color: #252a32;
+}
+
+.modal_body {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 20px 22px;
+}
+
+.modal_lead {
+  margin: 0 0 18px;
+  font-size: 15px;
+  line-height: 1.55;
+}
+
+.modal_stats,
+.result_summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.modal_stat,
+.result_summary_item {
+  padding: 12px;
+  background: #f4f5f7;
+  border: 1px solid #dfe2e6;
+  border-radius: 7px;
+  text-align: center;
+}
+
+.modal_stat strong,
+.result_summary_item strong {
+  display: block;
+  color: #252a32;
+  font-size: 22px;
+  line-height: 1.1;
+}
+
+.modal_stat span,
+.result_summary_item span {
+  display: block;
+  margin-top: 4px;
+  color: #69717d;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.type_breakdown {
+  margin-bottom: 18px;
+}
+
+.type_breakdown h3,
+.result_bundle_body h4 {
+  margin: 0 0 8px;
+  color: #404650;
+  font-size: 13px;
+}
+
+.type_breakdown ul,
+.result_list {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.type_breakdown li {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 7px 9px;
+  border-bottom: 1px solid #eceef1;
+}
+
+.type_breakdown li:last-child {
+  border-bottom: 0;
+}
+
+.modal_warning {
+  padding: 13px 14px;
+  margin-bottom: 16px;
+  background: #fff3cd;
+  color: #664d03;
+  border: 1px solid #e9cf78;
+  border-radius: 7px;
+}
+
+.modal_warning strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.modal_warning p,
+.modal_note {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.modal_note {
+  color: #69717d;
+  font-size: 12.5px;
+}
+
+.modal_footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 14px 22px;
+  background: #f7f8f9;
+  border-top: 1px solid #e1e4e8;
+}
+
+.modal_primary_button,
+.modal_secondary_button {
+  min-width: 94px;
+  padding: 8px 14px;
+  border-radius: 5px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.modal_primary_button {
+  background: #f4511e;
+  color: #fff;
+  border: 1px solid #d94316;
+}
+
+.modal_primary_button:hover,
+.modal_primary_button:focus-visible {
+  background: #dc4318;
+}
+
+.modal_secondary_button {
+  background: #fff;
+  color: #3d434c;
+  border: 1px solid #b8bec7;
+}
+
+.modal_secondary_button:hover,
+.modal_secondary_button:focus-visible {
+  background: #eef0f3;
+}
+
+.result_success_summary {
+  background: #e7f5ec;
+  border-color: #b9dfc7;
+}
+
+.result_success_summary strong {
+  color: #17653a;
+}
+
+.result_failure_summary {
+  background: #fbeaec;
+  border-color: #efc2c8;
+}
+
+.result_failure_summary strong {
+  color: #9c2636;
+}
+
+.export_status {
+  padding: 10px 12px;
+  margin-bottom: 16px;
+  border: 1px solid;
+  border-radius: 6px;
+}
+
+.export_status_success {
+  background: #e7f5ec;
+  color: #17653a;
+  border-color: #b9dfc7;
+}
+
+.export_status_failure {
+  background: #fbeaec;
+  color: #9c2636;
+  border-color: #efc2c8;
+}
+
+.result_groups {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.result_bundle {
+  overflow: hidden;
+  border: 1px solid #d9dde3;
+  border-radius: 7px;
+}
+
+.result_bundle summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 11px 13px;
+  background: #f4f5f7;
+  color: #353b44;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.result_bundle[open] summary {
+  border-bottom: 1px solid #d9dde3;
+}
+
+.result_bundle_counts {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.result_count_success,
+.result_count_failure {
+  padding: 2px 7px;
+  border-radius: 999px;
+}
+
+.result_count_success {
+  background: #d9efdf;
+  color: #17653a;
+}
+
+.result_count_failure {
+  background: #f5d9dd;
+  color: #9c2636;
+}
+
+.result_bundle_body {
+  padding: 13px;
+}
+
+.result_bundle_body h4:not(:first-child) {
+  margin-top: 14px;
+}
+
+.result_list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.result_list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  padding: 8px 10px;
+  border-radius: 5px;
+}
+
+.result_list strong,
+.result_list small {
+  display: block;
+}
+
+.result_list small {
+  margin-top: 2px;
+  color: #626a75;
+  line-height: 1.35;
+}
+
+.result_success {
+  background: #f0f8f3;
+}
+
+.result_failure {
+  background: #fcf0f2;
+}
+
+.result_icon {
+  flex: 0 0 auto;
+  width: 18px;
+  font-size: 17px;
+  font-weight: 800;
+  line-height: 1.1;
+  text-align: center;
+}
+
+.result_success .result_icon {
+  color: #20824b;
+}
+
+.result_failure .result_icon {
+  color: #b52f42;
+}
+
+@media (max-width: 600px) {
+  .modal_backdrop {
+    align-items: flex-end;
+    padding: 10px;
+  }
+
+  .modal {
+    max-height: 92vh;
+  }
+
+  .modal_stats,
+  .result_summary {
+    grid-template-columns: 1fr;
+  }
+
+  .result_bundle summary {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -397,6 +397,12 @@ tr.expired {
   border-color: #b9dfc7;
 }
 
+.export_status_warning {
+  background: #fff3cd;
+  color: #664d03;
+  border-color: #ffecb5;
+}
+
 .export_status_failure {
   background: #fbeaec;
   color: #9c2636;

--- a/src/styles.css
+++ b/src/styles.css
@@ -65,6 +65,12 @@
   border-color: #b6d4fe;
 }
 
+.hb_extractor-flash-toast_warning {
+  background: #fff3cd;
+  color: #664d03;
+  border-color: #ffecb5;
+}
+
 .hb_extractor-flash-toast_error {
   background: #f8d7da;
   color: #842029;

--- a/src/styles.css
+++ b/src/styles.css
@@ -55,7 +55,8 @@
   text-align: center;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
-  transform: translate(-50%, -50%);
+  transform: translate3d(-50%, -50%, 0) scale(1);
+  backface-visibility: hidden;
 }
 
 .hb_extractor-flash-toast_default {
@@ -73,26 +74,26 @@
 @keyframes hb_extractor-flash-toast-flash {
   0% {
     opacity: 0.35;
-    transform: translate(-50%, calc(-50% + 8px)) scale(0.96);
+    transform: translate3d(-50%, calc(-50% + 8px), 0) scale(0.96);
     filter: brightness(1.15);
   }
 
   35% {
     opacity: 1;
-    transform: translate(-50%, -50%) scale(1.03);
+    transform: translate3d(-50%, -50%, 0) scale(1.03);
     filter: brightness(1.15);
   }
 
   100% {
     opacity: 1;
-    transform: translate(-50%, -50%) scale(1);
+    transform: translate3d(-50%, -50%, 0) scale(1);
     filter: none;
   }
 }
 
 .hb_extractor-flash-toast_flash {
   animation: hb_extractor-flash-toast-flash 700ms ease-out both;
-  transform-origin: center;
+  will-change: transform, opacity, filter;
 }
 
 #hb_extractor-container details {

--- a/src/styles.css
+++ b/src/styles.css
@@ -41,7 +41,7 @@
   position: fixed;
   top: 50%;
   left: 50%;
-  z-index: 999999;
+  z-index: 1000001;
   max-width: 440px;
   max-height: 55vh;
   overflow: auto;

--- a/src/styles.css
+++ b/src/styles.css
@@ -135,6 +135,8 @@
   box-shadow: 0 3px 10px rgba(0, 0, 0, 0.16);
   font-size: 13.5px;
   line-height: 1.45;
+  transform: translate3d(0, 0, 0);
+  backface-visibility: hidden;
 }
 
 .hb_extractor-notice p {

--- a/src/styles.css
+++ b/src/styles.css
@@ -91,7 +91,8 @@
 }
 
 .hb_extractor-flash-toast_flash {
-  animation: hb_extractor-flash-toast-flash 700ms ease-out;
+  animation: hb_extractor-flash-toast-flash 700ms ease-out both;
+  transform-origin: center;
 }
 
 #hb_extractor-container details {

--- a/src/table-filter.ts
+++ b/src/table-filter.ts
@@ -1,0 +1,66 @@
+export interface SearchBuilderCriterion {
+  condition: string
+  data: string
+  value: string[]
+  [key: string]: unknown
+}
+
+export interface SearchBuilderGroup {
+  criteria: Array<SearchBuilderCriterion | SearchBuilderGroup>
+  logic: 'AND' | 'OR'
+  [key: string]: unknown
+}
+
+const inverseConditions: Record<string, string> = {
+  '!=': '=',
+  '!between': 'between',
+  '!contains': 'contains',
+  '!ends': 'ends',
+  '!null': 'null',
+  '!starts': 'starts',
+  // Table.tsx defines date “>” as on-or-after, making it the exact inverse of “<”.
+  '<': '>',
+  '=': '!=',
+  '>': '<',
+  between: '!between',
+  contains: '!contains',
+  ends: '!ends',
+  null: '!null',
+  starts: '!starts',
+}
+
+const isGroup = (value: SearchBuilderCriterion | SearchBuilderGroup): value is SearchBuilderGroup =>
+  Array.isArray(value.criteria)
+
+export const hasSearchBuilderCriteria = (group: SearchBuilderGroup): boolean =>
+  group.criteria.some((criterion) =>
+    isGroup(criterion)
+      ? hasSearchBuilderCriteria(criterion)
+      : typeof criterion.condition === 'string' && criterion.condition.length > 0
+  )
+
+export const invertSearchBuilderGroup = (group: SearchBuilderGroup): SearchBuilderGroup => ({
+  ...group,
+  logic: group.logic === 'AND' ? 'OR' : 'AND',
+  criteria: group.criteria.map((criterion) => {
+    if (isGroup(criterion)) return invertSearchBuilderGroup(criterion)
+
+    if (!criterion.condition) return { ...criterion }
+
+    const condition = inverseConditions[criterion.condition]
+    if (!condition) {
+      throw new Error(`The “${criterion.condition}” filter condition cannot be inverted.`)
+    }
+
+    return { ...criterion, condition }
+  }),
+})
+
+export interface SearchBuilderApi<TableApi = unknown> {
+  getDetails: (deFormatDates?: boolean) => SearchBuilderGroup
+  rebuild: (state?: SearchBuilderGroup, redraw?: boolean) => TableApi
+}
+
+export type WithSearchBuilder<TableApi> = TableApi & {
+  searchBuilder: SearchBuilderApi<TableApi>
+}

--- a/src/table-filter.ts
+++ b/src/table-filter.ts
@@ -25,6 +25,8 @@ const inverseConditions: Record<string, string> = {
   between: '!between',
   contains: '!contains',
   ends: '!ends',
+  expired: 'notExpired',
+  notExpired: 'expired',
   null: '!null',
   starts: '!starts',
 }

--- a/src/table-filter.ts
+++ b/src/table-filter.ts
@@ -18,7 +18,7 @@ const inverseConditions: Record<string, string> = {
   '!ends': 'ends',
   '!null': 'null',
   '!starts': 'starts',
-  // Table.tsx defines date “>” as on-or-after, making it the exact inverse of “<”.
+  // Table.tsx defines date ">" as on-or-after, making it the exact inverse of "<".
   '<': '>',
   '=': '!=',
   '>': '<',
@@ -29,10 +29,15 @@ const inverseConditions: Record<string, string> = {
   starts: '!starts',
 }
 
-const isGroup = (value: SearchBuilderCriterion | SearchBuilderGroup): value is SearchBuilderGroup =>
-  Array.isArray(value.criteria)
+const isGroup = (value: unknown): value is SearchBuilderGroup =>
+  value !== null &&
+  typeof value === 'object' &&
+  Array.isArray((value as Partial<SearchBuilderGroup>).criteria)
 
-export const hasSearchBuilderCriteria = (group: SearchBuilderGroup): boolean =>
+export const hasSearchBuilderCriteria = (
+  group: Partial<SearchBuilderGroup> | null | undefined
+): group is SearchBuilderGroup =>
+  Array.isArray(group?.criteria) &&
   group.criteria.some((criterion) =>
     isGroup(criterion)
       ? hasSearchBuilderCriteria(criterion)
@@ -49,7 +54,7 @@ export const invertSearchBuilderGroup = (group: SearchBuilderGroup): SearchBuild
 
     const condition = inverseConditions[criterion.condition]
     if (!condition) {
-      throw new Error(`The “${criterion.condition}” filter condition cannot be inverted.`)
+      throw new Error(`The "${criterion.condition}" filter condition cannot be inverted.`)
     }
 
     return { ...criterion, condition }

--- a/src/table-filter.ts
+++ b/src/table-filter.ts
@@ -27,6 +27,10 @@ const inverseConditions: Record<string, string> = {
   ends: '!ends',
   expired: 'notExpired',
   notExpired: 'expired',
+  regionRestricted: 'regionUnrestricted',
+  regionUnrestricted: 'regionRestricted',
+  regionRedeemable: 'regionNotRedeemable',
+  regionNotRedeemable: 'regionRedeemable',
   null: '!null',
   starts: '!starts',
 }

--- a/src/table-state.ts
+++ b/src/table-state.ts
@@ -1,0 +1,34 @@
+import type { Api, SearchInput } from 'datatables.net-dt'
+import type { Product } from './util'
+import type { SearchBuilderGroup, WithSearchBuilder } from './table-filter'
+
+export interface TableState {
+  searchBuilder: SearchBuilderGroup
+  globalSearch: SearchInput<Product>
+  columnSearches: string[]
+  order: Array<[number, 'asc' | 'desc']>
+  pageLength: number
+  page: number
+}
+
+export const captureTableState = (dt: Api<Product>): TableState => ({
+  searchBuilder: (dt as WithSearchBuilder<Api<Product>>).searchBuilder.getDetails(true),
+  globalSearch: dt.search(),
+  columnSearches: dt.columns().search().toArray().map(String),
+  order: dt.order() as Array<[number, 'asc' | 'desc']>,
+  pageLength: dt.page.len(),
+  page: dt.page(),
+})
+
+export const restoreTableState = (dt: Api<Product>, state: TableState): void => {
+  const searchBuilder = (dt as WithSearchBuilder<Api<Product>>).searchBuilder
+  searchBuilder.rebuild(state.searchBuilder, false)
+  dt.search(state.globalSearch)
+  state.columnSearches.forEach((search, index) => dt.column(index).search(search))
+  dt.order(state.order)
+  dt.page.len(state.pageLength)
+  dt.draw(false)
+
+  const lastPage = Math.max(0, dt.page.info().pages - 1)
+  dt.page(Math.min(state.page, lastPage)).draw('page')
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -529,7 +529,7 @@ const fetchOwnedApps = async (): Promise<number[] | null> =>
       return null
     })
 
-type FlashToastType = 'default' | 'error'
+type FlashToastType = 'default' | 'warning' | 'error'
 
 const getFlashToastDuration = (message: string): number => {
   const trimmed = message.trim()
@@ -551,7 +551,7 @@ export const showFlashToast = (message: string, type: FlashToastType = 'default'
   flashToastEl.textContent = message
   flashToastEl.hidden = false
   flashToastEl.className = `hb_extractor-flash-toast hb_extractor-flash-toast_${type}`
-  flashToastEl.setAttribute('role', type === 'error' ? 'alert' : 'status')
+  flashToastEl.setAttribute('role', type === 'default' ? 'status' : 'alert')
 
   void flashToastEl.offsetWidth
   flashToastEl.classList.add('hb_extractor-flash-toast_flash')

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import LZString from 'lz-string'
+import { hasRedeemedKeyValue, type RedeemedKeyValue } from './redeemed-key'
 
 export interface Order {
   created: string
@@ -17,7 +18,7 @@ export interface Order {
       is_gift: boolean
       key_type: string
       keyindex: number
-      redeemed_key_val?: string
+      redeemed_key_val?: RedeemedKeyValue
       steam_app_id?: number | null
       sold_out?: boolean
       direct_redeem?: boolean
@@ -43,7 +44,7 @@ export interface Product {
   human_name: string
   key_type: string
   type: 'Key' | 'Gift' | ''
-  redeemed_key_val: string
+  redeemed_key_val: RedeemedKeyValue | ''
   is_gift: boolean
   is_expired: boolean
   owned: 'Yes' | 'No' | ''
@@ -312,6 +313,10 @@ export const getProducts = (
             : 'No'
         : ''
 
+      const redeemedKey = hasRedeemedKeyValue(product.redeemed_key_val)
+        ? product.redeemed_key_val
+        : ''
+
       return {
         machine_name: product.machine_name || '',
         category: getCategory(order.product.category),
@@ -319,8 +324,8 @@ export const getProducts = (
         category_human_name: order.product.human_name || '',
         human_name: product.human_name || product.machine_name || '',
         key_type: product.key_type || '',
-        type: product.is_gift ? 'Gift' : product.redeemed_key_val ? 'Key' : '',
-        redeemed_key_val: product.redeemed_key_val || '',
+        type: product.is_gift ? 'Gift' : redeemedKey ? 'Key' : '',
+        redeemed_key_val: redeemedKey,
         is_gift: product.is_gift || false,
         is_expired: isExpired,
         expiry_date: expiry,
@@ -337,25 +342,55 @@ export const getProducts = (
   )
 }
 
-export const redeem = async (product: Product, gift = false): Promise<string> => {
-  const data = await fetch('https://www.humblebundle.com/humbler/redeemkey', {
+type RedeemResponse = {
+  success?: boolean
+  error_msg?: string
+  error?: string
+  giftkey?: unknown
+  key?: unknown
+}
+
+export const redeem = async (product: Product, gift = false): Promise<RedeemedKeyValue> => {
+  if (product.keyindex == null) throw new Error('Missing Humble key index')
+
+  const body = new URLSearchParams({
+    keytype: product.machine_name,
+    key: product.category_id,
+    keyindex: String(product.keyindex),
+  })
+
+  if (gift) body.set('gift', 'true')
+
+  const response = await fetch('https://www.humblebundle.com/humbler/redeemkey', {
     credentials: 'include',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
     },
-    body: `keytype=${product.machine_name}&key=${product.category_id}&keyindex=${product.keyindex}${gift ? '&gift=true' : ''}`,
+    body,
     method: 'POST',
     mode: 'cors',
-  }).then((res) => res.json())
+  })
+  let data: RedeemResponse
 
-  if (!data?.success) {
-    throw new Error(data?.error_msg || data?.error || 'Failed to reveal key')
+  try {
+    data = (await response.json()) as RedeemResponse
+  } catch {
+    throw new Error(`Humble returned an invalid response (HTTP ${response.status})`)
+  }
+
+  if (!response.ok || !data.success) {
+    throw new Error(
+      data.error_msg || data.error || `Failed to reveal key (HTTP ${response.status})`
+    )
   }
 
   const value = gift ? data.giftkey : data.key
-  if (!value) throw new Error('Failed to reveal key')
+  if (!hasRedeemedKeyValue(value)) throw new Error('Failed to reveal key')
 
-  return gift ? `https://www.humblebundle.com/gift?key=${value}` : value
+  if (!gift) return value
+  if (typeof value !== 'string') throw new Error('Humble returned an invalid gift key')
+
+  return `https://www.humblebundle.com/gift?key=${value}`
 }
 
 type SteamUserData = {
@@ -537,6 +572,16 @@ export const showErrorToast = (error: unknown, fallback = 'Failed'): void => {
     error instanceof Error ? error.message || fallback : error == null ? fallback : String(error)
 
   showFlashToast(message, 'error')
+}
+
+export function copyToClipboard(text: string): boolean {
+  try {
+    GM_setClipboard(text, 'text/plain')
+    return true
+  } catch (error) {
+    showErrorToast(error, 'Failed to copy to clipboard')
+    return false
+  }
 }
 
 type SteamNoticeLink = {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,6 @@
 import LZString from 'lz-string'
 import { hasRedeemedKeyValue, type RedeemedKeyValue } from './redeemed-key'
+import { normalizeCountryCodes, type RegionRestrictions } from './region'
 
 export interface Order {
   created: string
@@ -36,7 +37,7 @@ export interface RedeemedDate {
   iso: string
 }
 
-export interface Product {
+export interface Product extends RegionRestrictions {
   machine_name: string
   category: 'Store' | 'Bundle' | 'Other' | 'Choice'
   category_id: string
@@ -339,6 +340,8 @@ export const getProducts = (
           steamAppId && owned === 'Yes'
             ? (redeemedMap[String(steamAppId)] ?? undefined)
             : undefined,
+        exclusive_countries: normalizeCountryCodes(product.exclusive_countries),
+        disallowed_countries: normalizeCountryCodes(product.disallowed_countries),
       }
     })
   )

--- a/src/util.ts
+++ b/src/util.ts
@@ -43,6 +43,7 @@ export interface Product {
   category_human_name: string
   human_name: string
   key_type: string
+  direct_redeem: boolean
   type: 'Key' | 'Gift' | ''
   redeemed_key_val: RedeemedKeyValue | ''
   is_gift: boolean
@@ -324,6 +325,7 @@ export const getProducts = (
         category_human_name: order.product.human_name || '',
         human_name: product.human_name || product.machine_name || '',
         key_type: product.key_type || '',
+        direct_redeem: product.direct_redeem || false,
         type: product.is_gift ? 'Gift' : redeemedKey ? 'Key' : '',
         redeemed_key_val: redeemedKey,
         is_gift: product.is_gift || false,

--- a/src/util.ts
+++ b/src/util.ts
@@ -592,6 +592,123 @@ type SteamNoticeLink = {
   onClick?: () => void
 }
 
+const STEAM_NOTICE_ID_PREFIX = 'hb_extractor-notice-steam-'
+const MAX_NOTICES = 5
+const NOTICE_EXIT_DURATION = 180
+const NOTICE_REFLOW_DURATION = 180
+const NOTICE_ENTER_DURATION = 240
+const NOTICE_AUTO_DISMISS_DURATION = 10_000
+const NOTICE_EASING = 'cubic-bezier(0.16, 1, 0.3, 1)'
+const pendingSteamNotices = new Set<HTMLElement>()
+const noticeDismissals = new WeakMap<HTMLElement, Promise<void>>()
+const noticeTimers = new WeakMap<HTMLElement, number>()
+const autoDismissNotices = new WeakSet<HTMLElement>()
+let noticeSequence = 0
+let noticeRenderQueue = Promise.resolve()
+
+const prefersReducedMotion = (): boolean =>
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+const animateNoticeIn = (notice: HTMLElement): void => {
+  if (prefersReducedMotion()) return
+
+  notice.animate(
+    [
+      { opacity: 0, transform: 'translate3d(6px, 14px, 0)' },
+      { opacity: 1, transform: 'translate3d(0, 0, 0)' },
+    ],
+    { duration: NOTICE_ENTER_DURATION, easing: NOTICE_EASING }
+  )
+}
+
+const clearNoticeTimer = (notice: HTMLElement): void => {
+  const timer = noticeTimers.get(notice)
+  if (timer === undefined) return
+
+  window.clearTimeout(timer)
+  noticeTimers.delete(notice)
+}
+
+const dismissNotice = (notice: HTMLElement): Promise<void> => {
+  const activeDismissal = noticeDismissals.get(notice)
+  if (activeDismissal) return activeDismissal
+
+  clearNoticeTimer(notice)
+
+  const dismissal = (async () => {
+    const root = notice.parentElement
+    if (!(root instanceof HTMLElement) || !notice.isConnected || prefersReducedMotion()) {
+      notice.remove()
+      return
+    }
+
+    const siblings = Array.from(root.children).filter(
+      (child): child is HTMLElement => child instanceof HTMLElement && child !== notice
+    )
+    const previousTops = new Map(
+      siblings.map((sibling) => [sibling, sibling.getBoundingClientRect().top])
+    )
+    const rootRect = root.getBoundingClientRect()
+    const noticeRect = notice.getBoundingClientRect()
+    const previousRootWidth = root.style.width
+
+    // Keep the container stable while the departing notice leaves normal flow.
+    root.style.width = `${rootRect.width}px`
+    Object.assign(notice.style, {
+      position: 'absolute',
+      top: `${noticeRect.top - rootRect.top}px`,
+      left: `${noticeRect.left - rootRect.left}px`,
+      width: `${noticeRect.width}px`,
+      boxSizing: 'border-box',
+    })
+
+    const animations = siblings.flatMap((sibling) => {
+      const deltaY = previousTops.get(sibling)! - sibling.getBoundingClientRect().top
+      if (Math.abs(deltaY) < 0.5) return []
+
+      return [
+        sibling.animate([{ top: `${deltaY}px` }, { top: '0px' }], {
+          duration: NOTICE_REFLOW_DURATION,
+          easing: NOTICE_EASING,
+        }),
+      ]
+    })
+
+    animations.push(
+      notice.animate(
+        [
+          { opacity: 1, transform: 'translate3d(0, 0, 0)' },
+          { opacity: 0, transform: 'translate3d(6px, -10px, 0)' },
+        ],
+        { duration: NOTICE_EXIT_DURATION, easing: 'ease-in', fill: 'forwards' }
+      )
+    )
+
+    await Promise.all(animations.map((animation) => animation.finished.catch(() => undefined)))
+    notice.remove()
+    root.style.width = previousRootWidth
+  })()
+
+  noticeDismissals.set(notice, dismissal)
+  return dismissal
+}
+
+const scheduleNoticeDismissal = (notice: HTMLElement, duration: number): void => {
+  const startTimer = () => {
+    clearNoticeTimer(notice)
+    noticeTimers.set(
+      notice,
+      window.setTimeout(() => void dismissNotice(notice), duration)
+    )
+  }
+
+  notice.addEventListener('mouseenter', () => clearNoticeTimer(notice))
+  notice.addEventListener('mouseleave', startTimer)
+  notice.addEventListener('focusin', () => clearNoticeTimer(notice))
+  notice.addEventListener('focusout', startTimer)
+  startTimer()
+}
+
 const ensureNoticeRoot = (): HTMLElement => {
   let root = document.getElementById('hb_extractor-notices')
 
@@ -604,16 +721,34 @@ const ensureNoticeRoot = (): HTMLElement => {
   return root
 }
 
+type SteamNoticeOptions = {
+  allowDuplicates?: boolean
+  autoDismissMs?: number
+}
+
+const hasSteamNotice = (id: string): boolean => {
+  if (Array.from(pendingSteamNotices).some((notice) => notice.dataset.noticeId === id)) {
+    return true
+  }
+
+  const root = document.getElementById('hb_extractor-notices')
+  return Array.from(root?.children ?? []).some(
+    (child) => child instanceof HTMLElement && child.dataset.noticeId === id
+  )
+}
+
 const showSteamNotice = (
   id: string,
   title: string,
   message: string | string[],
-  links: SteamNoticeLink[]
+  links: SteamNoticeLink[],
+  options: SteamNoticeOptions = {}
 ): void => {
-  if (document.getElementById(id)) return
+  if (!options.allowDuplicates && hasSteamNotice(id)) return
 
   const notice = document.createElement('div')
-  notice.id = id
+  notice.id = `${id}-${++noticeSequence}`
+  notice.dataset.noticeId = id
   notice.className = 'hb_extractor-notice'
 
   const heading = document.createElement('strong')
@@ -624,7 +759,7 @@ const showSteamNotice = (
   close.className = 'hb_extractor-notice-close'
   close.title = 'Dismiss'
   close.textContent = '×'
-  close.addEventListener('click', () => notice.remove())
+  close.addEventListener('click', () => void dismissNotice(notice))
 
   const body = document.createElement('p')
   const messageLines = Array.isArray(message) ? message : [message]
@@ -648,17 +783,70 @@ const showSteamNotice = (
   }
 
   notice.append(heading, close, body, actions)
-  ensureNoticeRoot().append(notice)
+  pendingSteamNotices.add(notice)
+  if (options.autoDismissMs !== undefined) autoDismissNotices.add(notice)
+
+  noticeRenderQueue = noticeRenderQueue.then(async () => {
+    if (!pendingSteamNotices.has(notice)) return
+
+    const root = ensureNoticeRoot()
+
+    while (root.childElementCount >= MAX_NOTICES) {
+      const oldestNotice =
+        Array.from(root.children).find(
+          (child): child is HTMLElement =>
+            child instanceof HTMLElement && autoDismissNotices.has(child)
+        ) ?? root.firstElementChild
+      if (!(oldestNotice instanceof HTMLElement)) break
+      await dismissNotice(oldestNotice)
+      if (!pendingSteamNotices.has(notice)) return
+    }
+
+    pendingSteamNotices.delete(notice)
+    root.append(notice)
+    animateNoticeIn(notice)
+
+    if (options.autoDismissMs !== undefined) {
+      scheduleNoticeDismissal(notice, options.autoDismissMs)
+    }
+  })
 }
 
 const clearSteamNotice = (id: string): void => {
-  document.getElementById(id)?.remove()
+  for (const notice of pendingSteamNotices) {
+    if (notice.dataset.noticeId === id) pendingSteamNotices.delete(notice)
+  }
+
+  const root = document.getElementById('hb_extractor-notices')
+  if (!root) return
+
+  for (const child of Array.from(root.children)) {
+    if (child instanceof HTMLElement && child.dataset.noticeId === id) {
+      clearNoticeTimer(child)
+      child.remove()
+    }
+  }
 }
 
 export const clearSteamNotices = (): void => {
-  document
-    .querySelectorAll<HTMLElement>('[id^="hb_extractor-notice-steam-"]')
-    .forEach((notice) => notice.remove())
+  for (const notice of pendingSteamNotices) {
+    if (notice.dataset.noticeId?.startsWith(STEAM_NOTICE_ID_PREFIX)) {
+      pendingSteamNotices.delete(notice)
+    }
+  }
+
+  const root = document.getElementById('hb_extractor-notices')
+  if (!root) return
+
+  for (const child of Array.from(root.children)) {
+    if (
+      child instanceof HTMLElement &&
+      child.dataset.noticeId?.startsWith(STEAM_NOTICE_ID_PREFIX)
+    ) {
+      clearNoticeTimer(child)
+      child.remove()
+    }
+  }
 }
 
 export const showSteamOwnedNotice = (usedCache: boolean, onOpen?: () => void): void => {
@@ -714,7 +902,8 @@ export const showSteamSupportNotice = (appId: number): void => {
         text: 'Open Support page',
         href: `https://help.steampowered.com/en/wizard/HelpWithGame?appid=${appId}`,
       },
-    ]
+    ],
+    { allowDuplicates: true, autoDismissMs: NOTICE_AUTO_DISMISS_DURATION }
   )
 }
 


### PR DESCRIPTION
## Summary

This improves the Advanced Exporter's key-revealing workflow, export reliability, table behavior, and error reporting.

Bulk reveals now require confirmation, run with bounded concurrency, display live progress, warn before keyless items are redeemed directly to linked third-party accounts, and produce a persistent results dialog showing individual successes and failures. Successful reveals update the affected table rows, while failed items remain unrevealed so they can be retried later.

Individual keyless reveals and gift-link requests now also require confirmation. Keyless reveal actions use a distinct link icon to communicate that the item redeems through a linked third-party account.

The exporter now supports object-valued Humble redemption responses, validates redemption responses more carefully, and uses the userscript clipboard API for more reliable copying.

Table state is preserved across product refreshes, nested SearchBuilder conditions can be logically inverted, and exports consistently use the currently filtered rows.

Revealing expired unrevealed items can now be attempted as keys or gift links.

Empty clipboard exports now produce export-specific warnings without replacing the existing clipboard contents.

Table navigation and filtering now also include jump-to-page navigation, Expired/Not Expired convenience conditions, and Humble-reported region restriction filtering.

Region-restricted items are marked with a compact padlock, with detailed country restrictions available in a selectable tooltip. SearchBuilder can filter by restriction status and country, and the underlying Humble country restriction metadata is included in CSV exports.

Notification handling now limits the number of stacked notices, automatically dismisses transient user-action notices, and keeps persistent background errors visible.

## Changes

### Key revealing and exports

- Support object-valued redeemed-key responses without producing `[object Object]`.
- Serialize object-valued responses correctly in key, ASF, clipboard, and CSV exports.
- Validate Humble redemption HTTP responses, JSON payloads, success state, key indexes, and returned values.
- Construct redemption requests with `URLSearchParams`.
- Process bulk reveals with bounded concurrency of up to five requests.
- Continue processing after individual reveal failures instead of aborting the entire batch.
- Add a confirmation dialog before revealing keys or creating gift links in bulk.
- Summarize the number of affected items, bundles, and key types before confirmation.
- Warn when keyless items may redeem directly to the third-party account linked to Humble.
- Require confirmation before individually revealing a keyless item or requesting its gift link.
- Identify the affected product, explain the direct-redemption behavior, and remind the user to verify the linked account.
- Keep the confirmation dialog open and display live progress while processing.
- Allow Escape to close idle confirmation and results dialogs.
- Prevent cancellation, backdrop dismissal, and Escape while processing.
- Add a persistent results dialog grouped by bundle.
- Show successful and failed items with their key type and failure message.
- Add a Copy Log action that copies the status results of the bulk reveal.
- Report whether the completed export was copied successfully.
- Remind users to paste the export before replacing it by copying the results log.
- Update only table rows whose values changed during a bulk reveal.
- Update individual rows immediately after revealing a key or creating a gift link.
- Allow expired unrevealed items to be attempted as keys or gift links.
- Always export the rows matching the current table filter and remove the separate filter-export toggle.
- Warn when a clipboard export is empty without replacing the existing clipboard contents, distinguishing between no rows, no revealed Steam keys, and no revealed keys.
- Add `Exclusive Countries` and `Disallowed Countries` columns to CSV exports using Humble's country restriction metadata.

### Table and filtering

- Preserve SearchBuilder conditions, global and column searches, sorting, page length, and pagination across product refreshes.
- Prevent overlapping product refreshes and report refresh failures.
- Add logical inversion for nested SearchBuilder conditions.
- Handle empty SearchBuilder state safely.
- Explain when filter inversion cannot be performed because no advanced conditions exist or only text searches are active.
- Add an Invert filter action for conditions created through SearchBuilder.
- Add jump-to-page navigation alongside the existing table pagination controls.
- Add `Expired` and `Not Expired` convenience conditions to the Exp. Date SearchBuilder filter.
- Add Region SearchBuilder conditions for restriction status and whether keys are redeemable in a selected country.

### Clipboard and interface

- Use `GM_setClipboard` for exports, individual keys, gift links, and results logs.
  - This allows for the user to select another active window and still have the copy succeed.
- Add the required `GM_setClipboard` userscript permission.
- Encode keys included in Steam registration URLs.
- Rename `Claim unredeemed games` to `Reveal unrevealed keys`.
- Use a distinct link icon for keyless reveal actions.
- Improve the reveal checkbox alignment, modal presentation, progress display, and toast behavior.
- Show Humble-reported region restrictions with a compact padlock in the Type column and a selectable detail tooltip with hover delay.
- Add and refine Type, Owned, and Redeemed header tooltips, and tighten and resize their information badges.
- Limit stacked notifications to five, automatically dismiss transient user-action notices after ten seconds while pausing on hover or focus, keep persistent background errors visible, and animate notification entry and removal.

## Notes

Bulk reveal failures are not retried automatically. Successfully revealed items are retained, while failed items remain unrevealed and can be retried by running the export again.

The bulk key-reveal workflow can be tested against exhausted keys (as a dry run), if the account has any available.

Filter inversion applies only to conditions created through SearchBuilder's `Add Condition` interface. Global and per-column text searches are preserved but cannot be logically inverted.

Keyless items may redeem immediately to a linked third-party account rather than producing a transferable key or gift link. The bulk and individual confirmation dialogs identify these items before processing.

Region restriction information comes from country restriction data reported by Humble and may not exactly reflect Steam activation restrictions for the assigned key.