### PR TITLE
feat: add downloadable exports and improve CSV and table UX

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -17,7 +17,14 @@ import { Table } from './components/Table'
 import { captureTableState, type TableState } from './table-state'
 import { Refresh } from './components/Refresh'
 import { Actions } from './components/Actions'
+import { KeylessRedemptionConfirmation } from './components/BulkRevealDialogs'
 import type { Api } from 'datatables.net-dt'
+
+type PendingKeylessRedemption = {
+  product: Product
+  gift: boolean
+  resolve: (confirmed: boolean) => void
+}
 
 export function App() {
   const [open, setOpen] = createSignal(false)
@@ -29,11 +36,27 @@ export function App() {
   const [pendingTableState, setPendingTableState] = createSignal<TableState | null>(null)
   const [dt, setDt] = createSignal<Api<Product> | null>(null)
 
+  const [pendingKeylessRedemption, setPendingKeylessRedemption] =
+    createSignal<PendingKeylessRedemption | null>(null)
+  const [keylessRedemptionProcessing, setKeylessRedemptionProcessing] = createSignal(false)
+
   let checkSteamAccountTimer: number | undefined
   let refreshInFlight: Promise<void> | null = null
+  const pendingSteamPageRefreshes = new Set<Promise<void>>()
 
   const refreshAfterSteamPageOpen = () => {
-    window.setTimeout(() => refreshProducts(), 3000)
+    const pendingRefresh = new Promise<void>((resolve) => {
+      window.setTimeout(() => {
+        void Promise.resolve()
+          .then(refreshProducts)
+          .catch((error) => showErrorToast(error, 'Failed to refresh products'))
+          .finally(() => {
+            pendingSteamPageRefreshes.delete(pendingRefresh)
+            resolve()
+          })
+      }, 3000)
+    })
+    pendingSteamPageRefreshes.add(pendingRefresh)
   }
 
   const checkSteamAccountChanged = () => {
@@ -148,6 +171,44 @@ export function App() {
     return refreshInFlight
   }
 
+  const waitForProductRefresh = async (): Promise<void> => {
+    while (refreshInFlight || pendingSteamPageRefreshes.size) {
+      const pending = [...pendingSteamPageRefreshes]
+      if (refreshInFlight) pending.push(refreshInFlight)
+      await Promise.all(pending)
+    }
+  }
+
+  const requestKeylessConfirmation = (product: Product, gift: boolean): Promise<boolean> => {
+    if (pendingKeylessRedemption()) return Promise.resolve(false)
+
+    setKeylessRedemptionProcessing(false)
+    return new Promise((resolve) => setPendingKeylessRedemption({ product, gift, resolve }))
+  }
+
+  const cancelKeylessRedemption = (): void => {
+    if (keylessRedemptionProcessing()) return
+
+    const pending = pendingKeylessRedemption()
+    if (!pending) return
+
+    setPendingKeylessRedemption(null)
+    pending.resolve(false)
+  }
+
+  const confirmKeylessRedemption = (): void => {
+    const pending = pendingKeylessRedemption()
+    if (!pending || keylessRedemptionProcessing()) return
+
+    setKeylessRedemptionProcessing(true)
+    pending.resolve(true)
+  }
+
+  const finishKeylessRedemption = (): void => {
+    setPendingKeylessRedemption(null)
+    setKeylessRedemptionProcessing(false)
+  }
+
   onMount(() => {
     const checkSteamAccountChangedAfterVisibility = () => {
       if (!document.hidden) checkSteamAccountChanged()
@@ -157,6 +218,7 @@ export function App() {
     document.addEventListener('visibilitychange', checkSteamAccountChangedAfterVisibility)
 
     onCleanup(() => {
+      pendingKeylessRedemption()?.resolve(false)
       window.clearTimeout(checkSteamAccountTimer)
       window.removeEventListener('focus', checkSteamAccountChanged)
       document.removeEventListener('visibilitychange', checkSteamAccountChangedAfterVisibility)
@@ -184,14 +246,30 @@ export function App() {
           {(loadedProducts) => (
             <Table
               products={loadedProducts}
+              latestProducts={products}
+              currentDt={dt}
               steamId={steamId}
               setDt={setDt}
+              waitForProductRefresh={waitForProductRefresh}
+              requestKeylessConfirmation={requestKeylessConfirmation}
+              finishKeylessRedemption={finishKeylessRedemption}
               initialState={pendingTableState()}
               onStateRestored={() => setPendingTableState(null)}
             />
           )}
         </Show>
-        <Actions dt={dt} />
+        <Show when={pendingKeylessRedemption()} keyed>
+          {(pending) => (
+            <KeylessRedemptionConfirmation
+              product={pending.product}
+              gift={pending.gift}
+              processing={keylessRedemptionProcessing}
+              onCancel={cancelKeylessRedemption}
+              onConfirm={confirmKeylessRedemption}
+            />
+          )}
+        </Show>
+        <Actions dt={dt} products={products} waitForProductRefresh={waitForProductRefresh} />
       </div>
     </>
   )

--- a/src/claim-report.ts
+++ b/src/claim-report.ts
@@ -152,5 +152,5 @@ export const formatClaimLog = <T extends ClaimProduct>(report: ClaimReport<T>): 
     }
   }
 
-  return lines.join('\n')
+  return `${lines.join('\n')}\n`
 }

--- a/src/claim-report.ts
+++ b/src/claim-report.ts
@@ -15,6 +15,8 @@ export type ClaimFailure<T extends ClaimProduct = ClaimProduct> = ClaimSuccess<T
   error: unknown
 }
 
+export type ExportDestination = 'clipboard' | 'download'
+
 export type ClaimTypeCount = {
   label: string
   count: number
@@ -34,8 +36,10 @@ export type ClaimReport<T extends ClaimProduct = ClaimProduct> = {
   failures: ClaimFailure<T>[]
   typeCounts: ClaimTypeCount[]
   keylessCount: number
-  exportCopied: boolean
+  exportDestination: ExportDestination
+  exportSucceeded: boolean
   exportEmpty: boolean
+  exportFilename: string | null
 }
 
 export type ClaimResultGroup<T extends ClaimProduct = ClaimProduct> = {
@@ -125,7 +129,10 @@ export const formatClaimLog = <T extends ClaimProduct>(report: ClaimReport<T>): 
     `Requested: ${requested}`,
     `Succeeded: ${report.successes.length}`,
     `Failed: ${report.failures.length}`,
-    `Export copied to clipboard: ${report.exportCopied ? 'Yes' : 'No'}`,
+    report.exportDestination === 'clipboard'
+      ? `Export copied to clipboard: ${report.exportSucceeded ? 'Yes' : 'No'}`
+      : `Export download started: ${report.exportSucceeded ? 'Yes' : 'No'}`,
+    ...(report.exportFilename ? [`Export filename: ${report.exportFilename}`] : []),
     `Keyless/direct-redemption items: ${report.keylessCount}`,
     '',
     'Type breakdown:',

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -16,6 +16,11 @@ import {
 } from '../table-filter'
 import { hasRedeemedKeyValue, serializeRedeemedKeyValue } from '../redeemed-key'
 import {
+  applyRedeemedProductState,
+  captureProductReferences,
+  resolveProductReferences,
+} from '../product-reference'
+import {
   exportCSV,
   loadCsvExportPreferences,
   resolveCsvColumnIds,
@@ -44,11 +49,9 @@ const claimProducts = async (
 ): Promise<{
   successes: ClaimSuccess<Product>[]
   failures: ClaimFailure<Product>[]
-  updated: Set<Product>
 }> => {
   const successes: ClaimSuccess<Product>[] = []
   const failures: ClaimFailure<Product>[] = []
-  const updated = new Set<Product>()
   let completed = 0
 
   await forEachConcurrent(products, CLAIM_CONCURRENCY, async (product, index) => {
@@ -56,7 +59,6 @@ const claimProducts = async (
       product.redeemed_key_val = await redeem(product, gift)
       product.type = gift ? 'Gift' : 'Key'
       product.is_gift = gift
-      updated.add(product)
       successes.push({ index, product })
     } catch (error) {
       console.error('Error redeeming product:', product.machine_name, error)
@@ -69,7 +71,7 @@ const claimProducts = async (
   successes.sort((left, right) => left.index - right.index)
   failures.sort((left, right) => left.index - right.index)
 
-  return { successes, failures, updated }
+  return { successes, failures }
 }
 
 const terminateExport = (text: string): string => (text ? `${text}\n` : '')
@@ -187,7 +189,15 @@ const getEmptyExportMessage = (type: ExportType, products: Product[]): string =>
   return 'Empty export'
 }
 
-export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
+export function Actions({
+  dt,
+  products,
+  waitForProductRefresh,
+}: {
+  dt: Accessor<Api<Product> | null>
+  products: Accessor<Product[] | undefined>
+  waitForProductRefresh: () => Promise<void>
+}) {
   const [exportType, setExportType] = createSignal<ExportType>('csv')
   const [claim, setClaim] = createSignal(false)
   const [claimType, setClaimType] = createSignal('key')
@@ -303,26 +313,63 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
     setExportingDestination(destination)
 
     try {
-      const toExport = table.rows({ search: 'applied' }).data().toArray() as Product[]
+      const initialSelection = table.rows({ search: 'applied' }).data().toArray() as Product[]
       const claimAsGift = claimType() === 'gift'
       const claimable = claim()
-        ? toExport.filter((product) => !hasRedeemedKeyValue(product.redeemed_key_val))
+        ? initialSelection.filter((product) => !hasRedeemedKeyValue(product.redeemed_key_val))
         : []
+      let toExport = initialSelection
       let report: ClaimReport<Product> | null = null
 
       if (claimable.length) {
+        const initialProducts = products()
+        if (!initialProducts) throw new Error('Product data is unavailable. Please try again.')
+
+        const selectionReferences = captureProductReferences(initialProducts, initialSelection)
+        const claimableReferences = captureProductReferences(initialProducts, claimable)
         const plan = createClaimPlan(claimable)
         const confirmed = await confirmBulkReveal(plan, claimAsGift, destination)
         if (!confirmed) return
 
-        const { successes, failures, updated } = await claimProducts(
-          claimable,
+        // A Steam notice can schedule a product refresh while the confirmation is open. Resolve the
+        // exact confirmed rows against the newest product objects before revealing anything.
+        await waitForProductRefresh()
+        const latestBeforeClaim = products()
+        if (!latestBeforeClaim) throw new Error('Product data is unavailable. Please try again.')
+
+        const currentClaimable = resolveProductReferences(claimableReferences, latestBeforeClaim)
+        const { successes, failures } = await claimProducts(
+          currentClaimable,
           claimAsGift,
           setBulkRevealProgress
         )
 
-        if (updated.size) {
-          table
+        // A refresh can also finish while reveal requests are in flight. Resolve once more, then
+        // carry successful reveal state onto the latest objects so refreshed fields (such as
+        // Steam ownership) and newly revealed keys are both preserved in the export.
+        await waitForProductRefresh()
+        const latestAfterClaim = products()
+        if (!latestAfterClaim) throw new Error('Product data is unavailable. Please try again.')
+
+        toExport = resolveProductReferences(selectionReferences, latestAfterClaim)
+        const latestClaimable = resolveProductReferences(claimableReferences, latestAfterClaim)
+        const updated = new Set<Product>()
+
+        const currentSuccesses: ClaimSuccess<Product>[] = successes.map(({ index, product }) => {
+          const latestProduct = latestClaimable[index]
+          applyRedeemedProductState(latestProduct, product)
+          updated.add(latestProduct)
+          return { index, product: latestProduct }
+        })
+        const currentFailures: ClaimFailure<Product>[] = failures.map(({ index, error }) => ({
+          index,
+          product: latestClaimable[index],
+          error,
+        }))
+
+        const currentTable = dt()
+        if (currentTable && updated.size) {
+          currentTable
             .rows((_index, product) => updated.has(product))
             .invalidate('data')
             .draw(false)
@@ -330,8 +377,8 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
 
         report = {
           gift: claimAsGift,
-          successes,
-          failures,
+          successes: currentSuccesses,
+          failures: currentFailures,
           typeCounts: plan.typeCounts,
           keylessCount: plan.keylessCount,
           exportDestination: destination,

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -137,6 +137,18 @@ const exportCSV = (products: Product[], delimiter: string): string => {
 }
 
 type ExportType = 'asf' | 'keys' | 'csv'
+type CsvDelimiterPreset = 'comma' | 'tab' | 'semicolon' | 'pipe' | 'custom'
+
+const getCsvDelimiter = (preset: CsvDelimiterPreset, customDelimiter: string): string => {
+  if (preset === 'comma') return ','
+  if (preset === 'tab') return '\t'
+  if (preset === 'semicolon') return ';'
+  if (preset === 'pipe') return '|'
+  return customDelimiter
+}
+
+const isValidCsvDelimiter = (delimiter: string): boolean =>
+  delimiter.length > 0 && !/["\r\n]/.test(delimiter)
 
 const padTimestampPart = (value: number): string => String(value).padStart(2, '0')
 
@@ -153,19 +165,34 @@ const formatLocalTimestamp = (date: Date): string =>
     padTimestampPart(date.getSeconds()),
   ].join('')
 
-const getExportFilename = (type: ExportType, date = new Date()): string => {
+const getExportFilename = (type: ExportType, delimiter: string, date = new Date()): string => {
   const timestamp = formatLocalTimestamp(date)
 
   if (type === 'asf') return `humble-bundle-asf-${timestamp}.keys`
   if (type === 'keys') return `humble-bundle-keys-${timestamp}.txt`
-  return `humble-bundle-export-${timestamp}.csv`
+
+  const extension =
+    delimiter === '\t' ? 'tsv' : delimiter === ',' || delimiter === ';' ? 'csv' : 'txt'
+  return `humble-bundle-export-${timestamp}.${extension}`
 }
 
-const downloadExport = (text: string, filename: string, type: ExportType): boolean => {
+const getExportMimeType = (type: ExportType, delimiter: string): string => {
+  if (type !== 'csv') return 'text/plain;charset=utf-8'
+  if (delimiter === '\t') return 'text/tab-separated-values;charset=utf-8'
+  if (delimiter === ',' || delimiter === ';') return 'text/csv;charset=utf-8'
+  return 'text/plain;charset=utf-8'
+}
+
+const downloadExport = (
+  text: string,
+  filename: string,
+  type: ExportType,
+  delimiter: string
+): boolean => {
   let url: string | null = null
 
   try {
-    const mimeType = type === 'csv' ? 'text/csv;charset=utf-8' : 'text/plain;charset=utf-8'
+    const mimeType = getExportMimeType(type, delimiter)
     url = URL.createObjectURL(new Blob([text], { type: mimeType }))
 
     const link = document.createElement('a')
@@ -209,11 +236,15 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
   const exporting = (): boolean => exportingDestination() !== null
   const [bulkRevealProcessing, setBulkRevealProcessing] = createSignal(false)
   const [bulkRevealProgress, setBulkRevealProgress] = createSignal(0)
-  const [separator, setSeparator] = createSignal(',')
+  const [csvDelimiterPreset, setCsvDelimiterPreset] = createSignal<CsvDelimiterPreset>('comma')
+  const [customCsvDelimiter, setCustomCsvDelimiter] = createSignal('')
   const [pendingConfirmation, setPendingConfirmation] = createSignal<PendingConfirmation | null>(
     null
   )
   const [claimReport, setClaimReport] = createSignal<ClaimReport<Product> | null>(null)
+  const csvDelimiter = (): string => getCsvDelimiter(csvDelimiterPreset(), customCsvDelimiter())
+  const hasValidDelimiter = (): boolean =>
+    exportType() !== 'csv' || isValidCsvDelimiter(csvDelimiter())
 
   const cancelConfirmation = (): void => {
     if (bulkRevealProcessing()) return
@@ -277,7 +308,16 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
     if (!table) return
 
     const type = exportType()
-    const delimiter = separator() || ','
+    const delimiter = csvDelimiter()
+    if (type === 'csv' && !isValidCsvDelimiter(delimiter)) {
+      showFlashToast(
+        delimiter
+          ? 'CSV delimiters cannot contain double quotes or line breaks'
+          : 'Choose a CSV delimiter or enter a custom delimiter',
+        'warning'
+      )
+      return
+    }
     setExportingDestination(destination)
 
     try {
@@ -341,8 +381,8 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
       if (destination === 'clipboard') {
         exportSucceeded = copyToClipboard(text)
       } else {
-        exportFilename = getExportFilename(type)
-        exportSucceeded = downloadExport(text, exportFilename, type)
+        exportFilename = getExportFilename(type, delimiter)
+        exportSucceeded = downloadExport(text, exportFilename, type, delimiter)
       }
 
       if (report) {
@@ -414,24 +454,49 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
           <option value="csv">CSV</option>
         </select>
         <Show when={exportType() === 'csv'}>
-          <label for="separator" class={styles.export_separator}>
-            Separator&nbsp;
-            <input
-              type="text"
-              name="separator"
-              id="separator"
-              value={separator()}
-              onInput={(event) => setSeparator(event.currentTarget.value)}
-              style={{ width: '5ch', 'text-align': 'center' }}
-              required
-            />
-          </label>
+          <div class={styles.export_delimiter}>
+            <label for="csvDelimiter">Delimiter</label>
+            <select
+              name="csvDelimiter"
+              id="csvDelimiter"
+              class={`${styles.select} ${styles.export_delimiter_select}`}
+              value={csvDelimiterPreset()}
+              onChange={(event) =>
+                setCsvDelimiterPreset(event.currentTarget.value as CsvDelimiterPreset)
+              }
+            >
+              <option value="comma">Comma</option>
+              <option value="tab">Tab</option>
+              <option value="semicolon">Semicolon</option>
+              <option value="pipe">Pipe</option>
+              <option value="custom">Custom…</option>
+            </select>
+            <Show when={csvDelimiterPreset() === 'custom'}>
+              <input
+                type="text"
+                name="customCsvDelimiter"
+                id="customCsvDelimiter"
+                class={styles.export_custom_delimiter}
+                value={customCsvDelimiter()}
+                onInput={(event) => setCustomCsvDelimiter(event.currentTarget.value)}
+                on:keydown={(event) => event.stopPropagation()}
+                on:keypress={(event) => event.stopPropagation()}
+                on:keyup={(event) => event.stopPropagation()}
+                aria-label="Custom CSV delimiter"
+                aria-required="true"
+                aria-invalid={!isValidCsvDelimiter(customCsvDelimiter())}
+                placeholder="Custom"
+                title="Enter a delimiter without double quotes or line breaks"
+                required
+              />
+            </Show>
+          </div>
         </Show>
         <button
           type="button"
           class="primary-button"
           onClick={() => void runExport('clipboard')}
-          disabled={!dt() || !exportType() || exporting()}
+          disabled={!dt() || !exportType() || !hasValidDelimiter() || exporting()}
         >
           {exportingDestination() === 'clipboard' &&
           !pendingConfirmation() &&
@@ -445,7 +510,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
           type="button"
           class={`primary-button ${styles.export_secondary_button}`}
           onClick={() => void runExport('download')}
-          disabled={!dt() || !exportType() || exporting()}
+          disabled={!dt() || !exportType() || !hasValidDelimiter() || exporting()}
         >
           {exportingDestination() === 'download' &&
           !pendingConfirmation() &&

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -9,6 +9,7 @@ import {
   type ExportDestination,
 } from '../claim-report'
 import { forEachConcurrent } from '../concurrency'
+import { downloadTextFile, formatLocalTimestamp } from '../download'
 import {
   hasSearchBuilderCriteria,
   invertSearchBuilderGroup,
@@ -113,21 +114,6 @@ const getCsvDelimiter = (preset: CsvDelimiterPreset, customDelimiter: string): s
 const isValidCsvDelimiter = (delimiter: string): boolean =>
   delimiter.length > 0 && !/["\r\n]/.test(delimiter)
 
-const padTimestampPart = (value: number): string => String(value).padStart(2, '0')
-
-const formatLocalTimestamp = (date: Date): string =>
-  [
-    date.getFullYear(),
-    padTimestampPart(date.getMonth() + 1),
-    padTimestampPart(date.getDate()),
-  ].join('') +
-  '-' +
-  [
-    padTimestampPart(date.getHours()),
-    padTimestampPart(date.getMinutes()),
-    padTimestampPart(date.getSeconds()),
-  ].join('')
-
 const getExportFilename = (type: ExportType, delimiter: string, date = new Date()): string => {
   const timestamp = formatLocalTimestamp(date)
 
@@ -152,30 +138,10 @@ const downloadExport = (
   type: ExportType,
   delimiter: string
 ): boolean => {
-  let url: string | null = null
-
   try {
-    const mimeType = getExportMimeType(type, delimiter)
-    url = URL.createObjectURL(new Blob([text], { type: mimeType }))
-
-    const link = document.createElement('a')
-    link.href = url
-    link.download = filename
-    link.style.display = 'none'
-    document.body.append(link)
-
-    try {
-      link.click()
-    } finally {
-      link.remove()
-    }
-
-    const objectUrl = url
-    window.setTimeout(() => URL.revokeObjectURL(objectUrl), 1000)
-    url = null
+    downloadTextFile(text, filename, getExportMimeType(type, delimiter))
     return true
   } catch (error) {
-    if (url) URL.revokeObjectURL(url)
     showErrorToast(error, 'Failed to start download')
     return false
   }

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -6,6 +6,7 @@ import {
   type ClaimPlan,
   type ClaimReport,
   type ClaimSuccess,
+  type ExportDestination,
 } from '../claim-report'
 import { forEachConcurrent } from '../concurrency'
 import {
@@ -24,6 +25,7 @@ const CLAIM_CONCURRENCY = 5
 type PendingConfirmation = {
   plan: ClaimPlan<Product>
   gift: boolean
+  destination: ExportDestination
   resolve: (confirmed: boolean) => void
 }
 
@@ -62,24 +64,30 @@ const claimProducts = async (
   return { successes, failures, updated }
 }
 
+const terminateExport = (text: string): string => (text ? `${text}\n` : '')
+
 const exportASF = (products: Product[]): string =>
-  products
-    .filter(
-      (product) =>
-        !product.is_gift &&
-        hasRedeemedKeyValue(product.redeemed_key_val) &&
-        product.key_type === 'steam'
-    )
-    .map(
-      (product) => `${product.human_name}\t${serializeRedeemedKeyValue(product.redeemed_key_val)}`
-    )
-    .join('\n')
+  terminateExport(
+    products
+      .filter(
+        (product) =>
+          !product.is_gift &&
+          hasRedeemedKeyValue(product.redeemed_key_val) &&
+          product.key_type === 'steam'
+      )
+      .map(
+        (product) => `${product.human_name}\t${serializeRedeemedKeyValue(product.redeemed_key_val)}`
+      )
+      .join('\n')
+  )
 
 const exportKeys = (products: Product[]): string =>
-  products
-    .filter((product) => !product.is_gift && hasRedeemedKeyValue(product.redeemed_key_val))
-    .map((product) => serializeRedeemedKeyValue(product.redeemed_key_val))
-    .join('\n')
+  terminateExport(
+    products
+      .filter((product) => !product.is_gift && hasRedeemedKeyValue(product.redeemed_key_val))
+      .map((product) => serializeRedeemedKeyValue(product.redeemed_key_val))
+      .join('\n')
+  )
 
 const escapeCsvField = (value: string, delimiter: string): string => {
   const needsQuotes =
@@ -116,17 +124,72 @@ const exportCSV = (products: Product[], delimiter: string): string => {
     return product[name as keyof Product]
   }
 
-  return [
-    header.map((name) => escapeCsvField(name, delimiter)).join(delimiter),
-    ...products.map((product) =>
-      header
-        .map((name) => escapeCsvField(serializeField(getCsvValue(product, name)), delimiter))
-        .join(delimiter)
-    ),
-  ].join('\r\n')
+  return terminateExport(
+    [
+      header.map((name) => escapeCsvField(name, delimiter)).join(delimiter),
+      ...products.map((product) =>
+        header
+          .map((name) => escapeCsvField(serializeField(getCsvValue(product, name)), delimiter))
+          .join(delimiter)
+      ),
+    ].join('\n')
+  )
 }
 
 type ExportType = 'asf' | 'keys' | 'csv'
+
+const padTimestampPart = (value: number): string => String(value).padStart(2, '0')
+
+const formatLocalTimestamp = (date: Date): string =>
+  [
+    date.getFullYear(),
+    padTimestampPart(date.getMonth() + 1),
+    padTimestampPart(date.getDate()),
+  ].join('') +
+  '-' +
+  [
+    padTimestampPart(date.getHours()),
+    padTimestampPart(date.getMinutes()),
+    padTimestampPart(date.getSeconds()),
+  ].join('')
+
+const getExportFilename = (type: ExportType, date = new Date()): string => {
+  const timestamp = formatLocalTimestamp(date)
+
+  if (type === 'asf') return `humble-bundle-asf-${timestamp}.keys`
+  if (type === 'keys') return `humble-bundle-keys-${timestamp}.txt`
+  return `humble-bundle-export-${timestamp}.csv`
+}
+
+const downloadExport = (text: string, filename: string, type: ExportType): boolean => {
+  let url: string | null = null
+
+  try {
+    const mimeType = type === 'csv' ? 'text/csv;charset=utf-8' : 'text/plain;charset=utf-8'
+    url = URL.createObjectURL(new Blob([text], { type: mimeType }))
+
+    const link = document.createElement('a')
+    link.href = url
+    link.download = filename
+    link.style.display = 'none'
+    document.body.append(link)
+
+    try {
+      link.click()
+    } finally {
+      link.remove()
+    }
+
+    const objectUrl = url
+    window.setTimeout(() => URL.revokeObjectURL(objectUrl), 1000)
+    url = null
+    return true
+  } catch (error) {
+    if (url) URL.revokeObjectURL(url)
+    showErrorToast(error, 'Failed to start download')
+    return false
+  }
+}
 
 const getEmptyExportMessage = (type: ExportType, products: Product[]): string => {
   if (!products.length) return 'Empty export: no rows in table'
@@ -140,7 +203,10 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
   const [exportType, setExportType] = createSignal<ExportType>('csv')
   const [claim, setClaim] = createSignal(false)
   const [claimType, setClaimType] = createSignal('key')
-  const [exporting, setExporting] = createSignal(false)
+  const [exportingDestination, setExportingDestination] = createSignal<ExportDestination | null>(
+    null
+  )
+  const exporting = (): boolean => exportingDestination() !== null
   const [bulkRevealProcessing, setBulkRevealProcessing] = createSignal(false)
   const [bulkRevealProgress, setBulkRevealProgress] = createSignal(0)
   const [separator, setSeparator] = createSignal(',')
@@ -167,10 +233,14 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
     pending.resolve(true)
   }
 
-  const confirmBulkReveal = (plan: ClaimPlan<Product>, gift: boolean): Promise<boolean> => {
+  const confirmBulkReveal = (
+    plan: ClaimPlan<Product>,
+    gift: boolean,
+    destination: ExportDestination
+  ): Promise<boolean> => {
     setBulkRevealProcessing(false)
     setBulkRevealProgress(0)
-    return new Promise((resolve) => setPendingConfirmation({ plan, gift, resolve }))
+    return new Promise((resolve) => setPendingConfirmation({ plan, gift, destination, resolve }))
   }
 
   onCleanup(() => pendingConfirmation()?.resolve(false))
@@ -202,11 +272,13 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
     }
   }
 
-  const exportToClipboard = async (): Promise<void> => {
+  const runExport = async (destination: ExportDestination): Promise<void> => {
     const table = dt()
     if (!table) return
 
-    setExporting(true)
+    const type = exportType()
+    const delimiter = separator() || ','
+    setExportingDestination(destination)
 
     try {
       const toExport = table.rows({ search: 'applied' }).data().toArray() as Product[]
@@ -218,7 +290,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
 
       if (claimable.length) {
         const plan = createClaimPlan(claimable)
-        const confirmed = await confirmBulkReveal(plan, claimAsGift)
+        const confirmed = await confirmBulkReveal(plan, claimAsGift, destination)
         if (!confirmed) return
 
         const { successes, failures, updated } = await claimProducts(
@@ -240,61 +312,60 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
           failures,
           typeCounts: plan.typeCounts,
           keylessCount: plan.keylessCount,
-          exportCopied: false,
+          exportDestination: destination,
+          exportSucceeded: false,
           exportEmpty: false,
+          exportFilename: null,
         }
       }
 
-      const delimiter = separator() || ','
       const text =
-        exportType() === 'asf'
+        type === 'asf'
           ? exportASF(toExport)
-          : exportType() === 'keys'
+          : type === 'keys'
             ? exportKeys(toExport)
             : exportCSV(toExport, delimiter)
       if (!text) {
-        showFlashToast(getEmptyExportMessage(exportType(), toExport), 'warning')
+        showFlashToast(getEmptyExportMessage(type, toExport), 'warning')
 
         if (report) {
           setPendingConfirmation(null)
-          setClaimReport({ ...report, exportCopied: false, exportEmpty: true })
+          setClaimReport({ ...report, exportEmpty: true })
         }
         return
       }
 
-      const exportCopied = copyToClipboard(text)
+      let exportSucceeded: boolean
+      let exportFilename: string | null = null
+
+      if (destination === 'clipboard') {
+        exportSucceeded = copyToClipboard(text)
+      } else {
+        exportFilename = getExportFilename(type)
+        exportSucceeded = downloadExport(text, exportFilename, type)
+      }
 
       if (report) {
         setPendingConfirmation(null)
-        setClaimReport({ ...report, exportCopied })
-      } else if (exportCopied) {
-        showFlashToast('Exported to clipboard')
+        setClaimReport({ ...report, exportSucceeded, exportFilename })
+      } else if (exportSucceeded) {
+        showFlashToast(
+          destination === 'clipboard'
+            ? 'Export copied to clipboard'
+            : `Download started: ${exportFilename}`
+        )
       }
     } catch (error) {
       showErrorToast(error, 'Export failed')
     } finally {
       setPendingConfirmation(null)
       setBulkRevealProcessing(false)
-      setExporting(false)
+      setExportingDestination(null)
     }
   }
 
   return (
     <>
-      <div class={styles.actions}>
-        <label for="separator">
-          CSV Separator&nbsp;
-          <input
-            type="text"
-            name="separator"
-            id="separator"
-            value=","
-            onInput={(event) => setSeparator(event.target.value)}
-            style={{ width: '5ch', 'text-align': 'center' }}
-            required
-          />
-        </label>
-      </div>
       <div class={styles.actions}>
         <label for="claim" class={styles.checkbox_label}>
           <input
@@ -335,22 +406,53 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
           id="export"
           class={styles.select}
           value={exportType()}
+          aria-label="Export format"
           onChange={(event) => setExportType(event.currentTarget.value as ExportType)}
         >
           <option value="asf">ASF</option>
           <option value="keys">Keys</option>
           <option value="csv">CSV</option>
         </select>
+        <Show when={exportType() === 'csv'}>
+          <label for="separator" class={styles.export_separator}>
+            Separator&nbsp;
+            <input
+              type="text"
+              name="separator"
+              id="separator"
+              value={separator()}
+              onInput={(event) => setSeparator(event.currentTarget.value)}
+              style={{ width: '5ch', 'text-align': 'center' }}
+              required
+            />
+          </label>
+        </Show>
         <button
           type="button"
           class="primary-button"
-          onClick={exportToClipboard}
+          onClick={() => void runExport('clipboard')}
           disabled={!dt() || !exportType() || exporting()}
         >
-          {exporting() && !pendingConfirmation() && !bulkRevealProcessing() ? (
-            <i class="hb hb-spin hb-spinner"></i>
+          {exportingDestination() === 'clipboard' &&
+          !pendingConfirmation() &&
+          !bulkRevealProcessing() ? (
+            <i class="hb hb-spin hb-spinner" aria-hidden="true"></i>
           ) : (
-            'Export'
+            'Copy'
+          )}
+        </button>
+        <button
+          type="button"
+          class={`primary-button ${styles.export_secondary_button}`}
+          onClick={() => void runExport('download')}
+          disabled={!dt() || !exportType() || exporting()}
+        >
+          {exportingDestination() === 'download' &&
+          !pendingConfirmation() &&
+          !bulkRevealProcessing() ? (
+            <i class="hb hb-spin hb-spinner" aria-hidden="true"></i>
+          ) : (
+            'Download'
           )}
         </button>
       </div>
@@ -360,6 +462,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
           <BulkRevealConfirmation
             plan={pending.plan}
             gift={pending.gift}
+            destination={pending.destination}
             processing={bulkRevealProcessing}
             progress={bulkRevealProgress}
             onCancel={cancelConfirmation}

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -15,8 +15,16 @@ import {
   type WithSearchBuilder,
 } from '../table-filter'
 import { hasRedeemedKeyValue, serializeRedeemedKeyValue } from '../redeemed-key'
+import {
+  exportCSV,
+  loadCsvExportPreferences,
+  resolveCsvColumnIds,
+  saveCsvExportPreferences,
+  type CsvExportPreferences,
+} from '../csv-export'
 import { copyToClipboard, redeem, showErrorToast, showFlashToast, type Product } from '../util'
 import { BulkRevealConfirmation, BulkRevealResults } from './BulkRevealDialogs'
+import { CsvExportSettingsDialog } from './CsvExportSettingsDialog'
 // @ts-expect-error missing types
 import styles from '../style.module.css'
 
@@ -88,53 +96,6 @@ const exportKeys = (products: Product[]): string =>
       .map((product) => serializeRedeemedKeyValue(product.redeemed_key_val))
       .join('\n')
   )
-
-const escapeCsvField = (value: string, delimiter: string): string => {
-  const needsQuotes =
-    value.includes('"') ||
-    value.includes('\n') ||
-    value.includes('\r') ||
-    (delimiter ? value.includes(delimiter) : false) ||
-    value.trim() !== value
-
-  return needsQuotes ? `"${value.replace(/"/g, '""')}"` : value
-}
-
-const serializeField = (value: unknown): string => {
-  if (value == null) return ''
-  if (typeof value === 'object') return JSON.stringify(value) ?? ''
-  return String(value)
-}
-
-const exportCSV = (products: Product[], delimiter: string): string => {
-  if (!products.length) return ''
-
-  const header = Object.keys(products[0]).flatMap((name) => {
-    if (name === 'redeemed_date') return ['redeemed_date_label', 'redeemed_date_iso']
-    if (name === 'exclusive_countries') return ['Exclusive Countries']
-    if (name === 'disallowed_countries') return ['Disallowed Countries']
-    return [name]
-  })
-
-  const getCsvValue = (product: Product, name: string): unknown => {
-    if (name === 'redeemed_date_label') return product.redeemed_date?.label ?? ''
-    if (name === 'redeemed_date_iso') return product.redeemed_date?.iso ?? ''
-    if (name === 'Exclusive Countries') return product.exclusive_countries.join(';')
-    if (name === 'Disallowed Countries') return product.disallowed_countries.join(';')
-    return product[name as keyof Product]
-  }
-
-  return terminateExport(
-    [
-      header.map((name) => escapeCsvField(name, delimiter)).join(delimiter),
-      ...products.map((product) =>
-        header
-          .map((name) => escapeCsvField(serializeField(getCsvValue(product, name)), delimiter))
-          .join(delimiter)
-      ),
-    ].join('\n')
-  )
-}
 
 type ExportType = 'asf' | 'keys' | 'csv'
 type CsvDelimiterPreset = 'comma' | 'tab' | 'semicolon' | 'pipe' | 'custom'
@@ -238,6 +199,10 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
   const [bulkRevealProgress, setBulkRevealProgress] = createSignal(0)
   const [csvDelimiterPreset, setCsvDelimiterPreset] = createSignal<CsvDelimiterPreset>('comma')
   const [customCsvDelimiter, setCustomCsvDelimiter] = createSignal('')
+  const [csvExportPreferences, setCsvExportPreferences] = createSignal<CsvExportPreferences>(
+    loadCsvExportPreferences()
+  )
+  const [csvSettingsOpen, setCsvSettingsOpen] = createSignal(false)
   const [pendingConfirmation, setPendingConfirmation] = createSignal<PendingConfirmation | null>(
     null
   )
@@ -245,6 +210,22 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
   const csvDelimiter = (): string => getCsvDelimiter(csvDelimiterPreset(), customCsvDelimiter())
   const hasValidDelimiter = (): boolean =>
     exportType() !== 'csv' || isValidCsvDelimiter(csvDelimiter())
+  const hasSelectedCsvColumns = (): boolean =>
+    exportType() !== 'csv' || resolveCsvColumnIds(csvExportPreferences()).length > 0
+
+  const closeCsvSettings = (): void => {
+    setCsvSettingsOpen(false)
+  }
+
+  const applyCsvSettings = (preferences: CsvExportPreferences): void => {
+    setCsvExportPreferences(preferences)
+    try {
+      saveCsvExportPreferences(preferences)
+    } catch (error) {
+      showErrorToast(error, 'Failed to save CSV export settings')
+    }
+    closeCsvSettings()
+  }
 
   const cancelConfirmation = (): void => {
     if (bulkRevealProcessing()) return
@@ -309,6 +290,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
 
     const type = exportType()
     const delimiter = csvDelimiter()
+    const preferences = csvExportPreferences()
     if (type === 'csv' && !isValidCsvDelimiter(delimiter)) {
       showFlashToast(
         delimiter
@@ -364,7 +346,7 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
           ? exportASF(toExport)
           : type === 'keys'
             ? exportKeys(toExport)
-            : exportCSV(toExport, delimiter)
+            : exportCSV(toExport, delimiter, preferences)
       if (!text) {
         showFlashToast(getEmptyExportMessage(type, toExport), 'warning')
 
@@ -491,12 +473,28 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
               />
             </Show>
           </div>
+          <button
+            type="button"
+            class={styles.btn}
+            onClick={() => setCsvSettingsOpen(true)}
+            disabled={!dt() || exporting()}
+            aria-haspopup="dialog"
+            title="Choose CSV columns and date formatting"
+          >
+            Columns…
+          </button>
         </Show>
         <button
           type="button"
           class="primary-button"
           onClick={() => void runExport('clipboard')}
-          disabled={!dt() || !exportType() || !hasValidDelimiter() || exporting()}
+          disabled={
+            !dt() ||
+            !exportType() ||
+            !hasValidDelimiter() ||
+            !hasSelectedCsvColumns() ||
+            exporting()
+          }
         >
           {exportingDestination() === 'clipboard' &&
           !pendingConfirmation() &&
@@ -510,7 +508,13 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
           type="button"
           class={`primary-button ${styles.export_secondary_button}`}
           onClick={() => void runExport('download')}
-          disabled={!dt() || !exportType() || !hasValidDelimiter() || exporting()}
+          disabled={
+            !dt() ||
+            !exportType() ||
+            !hasValidDelimiter() ||
+            !hasSelectedCsvColumns() ||
+            exporting()
+          }
         >
           {exportingDestination() === 'download' &&
           !pendingConfirmation() &&
@@ -521,6 +525,17 @@ export function Actions({ dt }: { dt: Accessor<Api<Product> | null> }) {
           )}
         </button>
       </div>
+
+      <Show when={csvSettingsOpen() && dt()} keyed>
+        {(table) => (
+          <CsvExportSettingsDialog
+            table={table}
+            preferences={csvExportPreferences()}
+            onCancel={closeCsvSettings}
+            onApply={applyCsvSettings}
+          />
+        )}
+      </Show>
 
       <Show when={pendingConfirmation()} keyed>
         {(pending) => (

--- a/src/components/BulkRevealDialogs.tsx
+++ b/src/components/BulkRevealDialogs.tsx
@@ -1,4 +1,4 @@
-import { For, onCleanup, onMount, Show, type Accessor } from 'solid-js'
+import { For, Show, type Accessor } from 'solid-js'
 import {
   formatClaimLog,
   getClaimTypeLabel,
@@ -9,6 +9,7 @@ import {
   type ClaimReport,
   type ExportDestination,
 } from '../claim-report'
+import { useModalBehavior } from '../modal'
 import { copyToClipboard, showFlashToast, type Product } from '../util'
 // @ts-expect-error missing types
 import styles from '../style.module.css'
@@ -44,18 +45,6 @@ const ClaimType = ({ product }: { product: Product }) => {
   )
 }
 
-const useEscapeKey = (onEscape: () => void, disabled?: Accessor<boolean>): void => {
-  const handleKeyDown = (event: KeyboardEvent): void => {
-    if (event.key !== 'Escape' || disabled?.()) return
-
-    event.preventDefault()
-    onEscape()
-  }
-
-  onMount(() => document.addEventListener('keydown', handleKeyDown))
-  onCleanup(() => document.removeEventListener('keydown', handleKeyDown))
-}
-
 export function KeylessRedemptionConfirmation({
   product,
   gift,
@@ -78,8 +67,12 @@ export function KeylessRedemptionConfirmation({
         'Continuing will redeem this item immediately to the third-party account linked to your',
         'Humble Bundle account. No transferable key will be shown.',
       ].join(' ')
-
-  useEscapeKey(onCancel, processing)
+  let dialogRef: HTMLElement | undefined
+  const { handleKeyDown, stopPropagation } = useModalBehavior({
+    dialog: () => dialogRef,
+    onEscape: onCancel,
+    escapeDisabled: processing,
+  })
 
   return (
     <div
@@ -88,12 +81,16 @@ export function KeylessRedemptionConfirmation({
       onMouseDown={(event) => event.target === event.currentTarget && !processing() && onCancel()}
     >
       <section
+        ref={dialogRef}
         class={styles.modal}
         role="dialog"
         aria-modal="true"
         aria-labelledby="hb_extractor-keyless-confirm-title"
         aria-busy={processing()}
         tabindex="-1"
+        on:keydown={handleKeyDown}
+        on:keypress={stopPropagation}
+        on:keyup={stopPropagation}
       >
         <header class={styles.modal_header}>
           <div>
@@ -195,7 +192,12 @@ export function BulkRevealConfirmation({
         'your Humble Bundle account; they will not produce transferable keys.',
       ].join(' ')
 
-  useEscapeKey(onCancel, processing)
+  let dialogRef: HTMLElement | undefined
+  const { handleKeyDown, stopPropagation } = useModalBehavior({
+    dialog: () => dialogRef,
+    onEscape: onCancel,
+    escapeDisabled: processing,
+  })
 
   return (
     <div
@@ -204,12 +206,16 @@ export function BulkRevealConfirmation({
       onMouseDown={(event) => event.target === event.currentTarget && !processing() && onCancel()}
     >
       <section
+        ref={dialogRef}
         class={styles.modal}
         role="dialog"
         aria-modal="true"
         aria-labelledby="hb_extractor-confirm-title"
         aria-busy={processing()}
         tabindex="-1"
+        on:keydown={handleKeyDown}
+        on:keypress={stopPropagation}
+        on:keyup={stopPropagation}
       >
         <header class={styles.modal_header}>
           <div>
@@ -363,8 +369,11 @@ export function BulkRevealResults({
   const groups = groupClaimResults(report)
   const requested = report.successes.length + report.failures.length
   let resultGroupsRef!: HTMLDivElement
-
-  useEscapeKey(onClose)
+  let dialogRef: HTMLElement | undefined
+  const { handleKeyDown, stopPropagation } = useModalBehavior({
+    dialog: () => dialogRef,
+    onEscape: onClose,
+  })
 
   const setAllBundlesOpen = (open: boolean): void => {
     for (const bundle of resultGroupsRef.querySelectorAll<HTMLDetailsElement>('details')) {
@@ -381,11 +390,15 @@ export function BulkRevealResults({
   return (
     <div class={styles.modal_backdrop} role="presentation">
       <section
+        ref={dialogRef}
         class={`${styles.modal} ${styles.modal_wide}`}
         role="dialog"
         aria-modal="true"
         aria-labelledby="hb_extractor-results-title"
         tabindex="-1"
+        on:keydown={handleKeyDown}
+        on:keypress={stopPropagation}
+        on:keyup={stopPropagation}
       >
         <header class={styles.modal_header}>
           <div>

--- a/src/components/BulkRevealDialogs.tsx
+++ b/src/components/BulkRevealDialogs.tsx
@@ -7,6 +7,7 @@ import {
   isKeylessProduct,
   type ClaimPlan,
   type ClaimReport,
+  type ExportDestination,
 } from '../claim-report'
 import { copyToClipboard, showFlashToast, type Product } from '../util'
 // @ts-expect-error missing types
@@ -166,6 +167,7 @@ export function KeylessRedemptionConfirmation({
 export function BulkRevealConfirmation({
   plan,
   gift,
+  destination,
   processing,
   progress,
   onCancel,
@@ -173,6 +175,7 @@ export function BulkRevealConfirmation({
 }: {
   plan: ClaimPlan<Product>
   gift: boolean
+  destination: ExportDestination
   processing: Accessor<boolean>
   progress: Accessor<number>
   onCancel: () => void
@@ -180,6 +183,8 @@ export function BulkRevealConfirmation({
 }) {
   const count = plan.products.length
   const action = gift ? 'create gift links for' : 'reveal'
+  const destinationVerb = destination === 'download' ? 'download' : 'copy'
+  const destinationProgress = destination === 'download' ? 'Downloading' : 'Copying'
   const keylessWarning = gift
     ? [
         'These may redeem directly to the third-party account linked to your Humble Bundle',
@@ -210,7 +215,9 @@ export function BulkRevealConfirmation({
           <div>
             <p class={styles.modal_eyebrow}>Bulk reveal confirmation</p>
             <h2 id="hb_extractor-confirm-title" class={styles.modal_title}>
-              {gift ? 'Create gift links and export?' : 'Reveal keys and export?'}
+              {gift
+                ? `Create gift links and ${destinationVerb}?`
+                : `Reveal keys and ${destinationVerb}?`}
             </h2>
           </div>
           <button
@@ -332,12 +339,12 @@ export function BulkRevealConfirmation({
             {processing() ? (
               <>
                 <i class="hb hb-spin hb-spinner" aria-hidden="true"></i>{' '}
-                {gift ? 'Creating & Exporting…' : 'Revealing & Exporting…'}
+                {gift ? 'Creating' : 'Revealing'} & {destinationProgress}…
               </>
             ) : gift ? (
-              'Create & Export'
+              `Create & ${destination === 'download' ? 'Download' : 'Copy'}`
             ) : (
-              'Reveal & Export'
+              `Reveal & ${destination === 'download' ? 'Download' : 'Copy'}`
             )}
           </button>
         </footer>
@@ -416,21 +423,33 @@ export function BulkRevealResults({
 
           <div
             class={`${styles.export_status} ${
-              report.exportCopied
+              report.exportSucceeded
                 ? styles.export_status_success
                 : report.exportEmpty
                   ? styles.export_status_warning
                   : styles.export_status_failure
             }`}
           >
-            {report.exportCopied ? (
-              <>
-                Export copied to clipboard. <strong>Paste it before copying the log.</strong>
-              </>
+            {report.exportSucceeded ? (
+              report.exportDestination === 'clipboard' ? (
+                <>
+                  Export copied to clipboard. <strong>Paste it before copying the log.</strong>
+                </>
+              ) : (
+                <>
+                  Download started: <strong>{report.exportFilename}</strong>
+                </>
+              )
             ) : report.exportEmpty ? (
-              'The reveal finished, but the selected export was empty. Your clipboard was left unchanged.'
-            ) : (
+              report.exportDestination === 'clipboard' ? (
+                'The reveal finished, but the selected export was empty. Your clipboard was left unchanged.'
+              ) : (
+                'The reveal finished, but the selected export was empty. No download was started.'
+              )
+            ) : report.exportDestination === 'clipboard' ? (
               'The reveal finished, but the export could not be copied to your clipboard.'
+            ) : (
+              'The reveal finished, but the download could not be started.'
             )}
           </div>
 

--- a/src/components/BulkRevealDialogs.tsx
+++ b/src/components/BulkRevealDialogs.tsx
@@ -404,7 +404,11 @@ export function BulkRevealResults({
   }
 
   return (
-    <div class={styles.modal_backdrop} role="presentation">
+    <div
+      class={styles.modal_backdrop}
+      role="presentation"
+      onMouseDown={(event) => event.target === event.currentTarget && event.preventDefault()}
+    >
       <section
         ref={dialogRef}
         class={`${styles.modal} ${styles.modal_wide}`}
@@ -461,7 +465,7 @@ export function BulkRevealResults({
           >
             {report.exportSucceeded ? (
               report.exportDestination === 'clipboard' ? (
-                <>Export copied to clipboard.</>
+                'Export copied to clipboard.'
               ) : (
                 <>
                   Download started: <strong>{report.exportFilename}</strong>

--- a/src/components/BulkRevealDialogs.tsx
+++ b/src/components/BulkRevealDialogs.tsx
@@ -111,7 +111,7 @@ export function KeylessRedemptionConfirmation({
           </button>
         </header>
 
-        <div class={styles.modal_body}>
+        <div class={styles.modal_body} data-modal-scroll-body>
           <p class={styles.modal_lead}>
             <strong>{product.human_name}</strong> is marked by Humble for direct redemption.
           </p>
@@ -238,7 +238,7 @@ export function BulkRevealConfirmation({
           </button>
         </header>
 
-        <div class={styles.modal_body}>
+        <div class={styles.modal_body} data-modal-scroll-body>
           <p class={styles.modal_lead}>
             The exporter is about to {action} <strong>{count}</strong>{' '}
             {pluralize(count, 'unrevealed item')} across <strong>{plan.bundleCount}</strong>{' '}
@@ -418,7 +418,7 @@ export function BulkRevealResults({
           </button>
         </header>
 
-        <div class={styles.modal_body}>
+        <div class={styles.modal_body} data-modal-scroll-body>
           <div class={styles.result_summary} aria-live="polite">
             <div class={styles.result_summary_item}>
               <strong>{requested}</strong>

--- a/src/components/BulkRevealDialogs.tsx
+++ b/src/components/BulkRevealDialogs.tsx
@@ -9,13 +9,17 @@ import {
   type ClaimReport,
   type ExportDestination,
 } from '../claim-report'
+import { downloadTextFile, formatLocalTimestamp } from '../download'
 import { useModalBehavior } from '../modal'
-import { copyToClipboard, showFlashToast, type Product } from '../util'
+import { copyToClipboard, showErrorToast, showFlashToast, type Product } from '../util'
 // @ts-expect-error missing types
 import styles from '../style.module.css'
 
 const pluralize = (count: number, singular: string, plural = `${singular}s`): string =>
   count === 1 ? singular : plural
+
+const getRevealLogFilename = (date = new Date()): string =>
+  `humble-bundle-reveal-log-${formatLocalTimestamp(date)}.log`
 
 const claimTypeIconClasses: Record<string, string> = {
   battlenet: 'hb-bnet',
@@ -368,6 +372,7 @@ export function BulkRevealResults({
 }) {
   const groups = groupClaimResults(report)
   const requested = report.successes.length + report.failures.length
+  const log = formatClaimLog(report)
   let resultGroupsRef!: HTMLDivElement
   let dialogRef: HTMLElement | undefined
   const { handleKeyDown, stopPropagation } = useModalBehavior({
@@ -382,8 +387,19 @@ export function BulkRevealResults({
   }
 
   const copyLog = (): void => {
-    if (copyToClipboard(formatClaimLog(report))) {
+    if (copyToClipboard(log)) {
       showFlashToast('Log copied to clipboard')
+    }
+  }
+
+  const downloadLog = (): void => {
+    const filename = getRevealLogFilename()
+
+    try {
+      downloadTextFile(log, filename)
+      showFlashToast(`Download started: ${filename}`)
+    } catch (error) {
+      showErrorToast(error, 'Failed to start log download')
     }
   }
 
@@ -445,9 +461,7 @@ export function BulkRevealResults({
           >
             {report.exportSucceeded ? (
               report.exportDestination === 'clipboard' ? (
-                <>
-                  Export copied to clipboard. <strong>Paste it before copying the log.</strong>
-                </>
+                <>Export copied to clipboard.</>
               ) : (
                 <>
                   Download started: <strong>{report.exportFilename}</strong>
@@ -555,12 +569,15 @@ export function BulkRevealResults({
           </div>
         </div>
 
-        <footer class={styles.modal_footer}>
+        <footer class={`${styles.modal_footer} ${styles.result_footer}`}>
           <button type="button" class={styles.modal_secondary_button} onClick={onClose}>
             Close
           </button>
           <button type="button" class={styles.modal_primary_button} onClick={copyLog} autofocus>
             Copy Log
+          </button>
+          <button type="button" class={styles.modal_secondary_button} onClick={downloadLog}>
+            Download Log
           </button>
         </footer>
       </section>

--- a/src/components/CsvExportSettingsDialog.tsx
+++ b/src/components/CsvExportSettingsDialog.tsx
@@ -1,0 +1,204 @@
+import { createSignal, For } from 'solid-js'
+import type { Api } from 'datatables.net-dt'
+import {
+  CSV_COLUMNS,
+  DEFAULT_CSV_COLUMN_IDS,
+  DEFAULT_CSV_EXPORT_PREFERENCES,
+  getBrowserTimeZone,
+  getCsvColumnHeader,
+  getVisibleCsvColumnIds,
+  resolveCsvColumnIds,
+  type CsvColumnId,
+  type CsvDateFormat,
+  type CsvExportPreferences,
+} from '../csv-export'
+import { useModalBehavior } from '../modal'
+import type { Product } from '../util'
+// @ts-expect-error missing types
+import styles from '../style.module.css'
+
+const sameColumnIds = (left: readonly CsvColumnId[], right: readonly CsvColumnId[]): boolean =>
+  left.length === right.length && left.every((id, index) => id === right[index])
+
+export function CsvExportSettingsDialog({
+  table,
+  preferences,
+  onCancel,
+  onApply,
+}: {
+  table: Api<Product>
+  preferences: CsvExportPreferences
+  onCancel: () => void
+  onApply: (preferences: CsvExportPreferences) => void
+}) {
+  const initialColumnIds = resolveCsvColumnIds(preferences)
+  const [selectedColumnIds, setSelectedColumnIds] = createSignal<CsvColumnId[]>(initialColumnIds)
+  const [dateFormat, setDateFormat] = createSignal<CsvDateFormat>(preferences.dateFormat)
+  const [usesDefaultColumns, setUsesDefaultColumns] = createSignal(preferences.columnIds === null)
+  let dialogRef: HTMLElement | undefined
+
+  const setColumns = (columnIds: readonly CsvColumnId[], useDefaults = false): void => {
+    const selected = new Set(columnIds)
+    setSelectedColumnIds(DEFAULT_CSV_COLUMN_IDS.filter((id) => selected.has(id)))
+    setUsesDefaultColumns(useDefaults)
+  }
+
+  const toggleColumn = (id: CsvColumnId, checked: boolean): void => {
+    const selected = new Set(selectedColumnIds())
+    if (checked) selected.add(id)
+    else selected.delete(id)
+    setColumns([...selected])
+  }
+
+  const selectVisible = (): void => {
+    const visible = table
+      .columns()
+      .indexes()
+      .toArray()
+      .map((index) => table.column(index).visible())
+    setColumns(getVisibleCsvColumnIds(visible))
+  }
+
+  const resetDefaults = (): void => {
+    setColumns(DEFAULT_CSV_COLUMN_IDS, true)
+    setDateFormat(DEFAULT_CSV_EXPORT_PREFERENCES.dateFormat)
+  }
+
+  const apply = (): void => {
+    const columnIds = selectedColumnIds()
+    if (!columnIds.length) return
+
+    onApply({
+      columnIds:
+        usesDefaultColumns() && sameColumnIds(columnIds, DEFAULT_CSV_COLUMN_IDS)
+          ? null
+          : [...columnIds],
+      dateFormat: dateFormat(),
+    })
+  }
+
+  const { handleKeyDown, stopPropagation } = useModalBehavior({
+    dialog: () => dialogRef,
+    onEscape: onCancel,
+  })
+
+  return (
+    <div
+      class={styles.modal_backdrop}
+      role="presentation"
+      onMouseDown={(event) => event.target === event.currentTarget && onCancel()}
+    >
+      <section
+        ref={dialogRef}
+        class={`${styles.modal} ${styles.modal_wide}`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="hb_extractor-csv-settings-title"
+        aria-describedby="hb_extractor-csv-settings-description"
+        tabindex="-1"
+        on:keydown={handleKeyDown}
+        on:keypress={stopPropagation}
+        on:keyup={stopPropagation}
+      >
+        <header class={styles.modal_header}>
+          <div>
+            <p class={styles.modal_eyebrow}>CSV export</p>
+            <h2 id="hb_extractor-csv-settings-title" class={styles.modal_title}>
+              Export options
+            </h2>
+          </div>
+          <button
+            type="button"
+            class={styles.modal_close}
+            aria-label="Cancel"
+            title="Cancel"
+            onClick={onCancel}
+          >
+            ×
+          </button>
+        </header>
+
+        <div class={styles.modal_body}>
+          <p id="hb_extractor-csv-settings-description" class={styles.csv_settings_intro}>
+            Choose which fields to include in CSV exports. Applied settings are remembered across
+            page reloads.
+          </p>
+
+          <div class={styles.csv_settings_section_header}>
+            <div>
+              <h3>Columns</h3>
+              <span class={styles.csv_settings_count} aria-live="polite">
+                {selectedColumnIds().length} of {CSV_COLUMNS.length} selected
+              </span>
+            </div>
+            <div class={styles.csv_settings_actions}>
+              <button type="button" onClick={() => setColumns(DEFAULT_CSV_COLUMN_IDS)}>
+                Select all
+              </button>
+              <button type="button" onClick={selectVisible}>
+                Select visible
+              </button>
+              <button type="button" onClick={() => setColumns([])}>
+                Clear all
+              </button>
+              <button type="button" onClick={resetDefaults}>
+                Reset to default
+              </button>
+            </div>
+          </div>
+
+          <div class={styles.csv_column_grid}>
+            <For each={CSV_COLUMNS}>
+              {(column) => (
+                <label class={styles.csv_column_option}>
+                  <input
+                    type="checkbox"
+                    checked={selectedColumnIds().includes(column.id)}
+                    onChange={(event) => toggleColumn(column.id, event.currentTarget.checked)}
+                  />
+                  <span>
+                    <strong>{column.label}</strong>
+                    <small>{getCsvColumnHeader(column.id)}</small>
+                  </span>
+                </label>
+              )}
+            </For>
+          </div>
+
+          <div class={styles.csv_date_settings}>
+            <div>
+              <label for="csvDateFormat">Date format</label>
+              <p>
+                Human-readable timestamps use your browser's local time zone ({getBrowserTimeZone()}
+                ). Date-only values remain date-only.
+              </p>
+            </div>
+            <select
+              id="csvDateFormat"
+              class={styles.select}
+              value={dateFormat()}
+              onChange={(event) => setDateFormat(event.currentTarget.value as CsvDateFormat)}
+            >
+              <option value="iso">ISO 8601</option>
+              <option value="human">Human-readable</option>
+            </select>
+          </div>
+        </div>
+
+        <footer class={styles.modal_footer}>
+          <button type="button" class={styles.modal_secondary_button} onClick={onCancel}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            class={`${styles.modal_primary_button} ${styles.csv_settings_apply}`}
+            onClick={apply}
+            disabled={!selectedColumnIds().length}
+          >
+            Apply
+          </button>
+        </footer>
+      </section>
+    </div>
+  )
+}

--- a/src/components/CsvExportSettingsDialog.tsx
+++ b/src/components/CsvExportSettingsDialog.tsx
@@ -118,7 +118,7 @@ export function CsvExportSettingsDialog({
           </button>
         </header>
 
-        <div class={styles.modal_body}>
+        <div class={styles.modal_body} data-modal-scroll-body>
           <p id="hb_extractor-csv-settings-description" class={styles.csv_settings_intro}>
             Choose which fields to include in CSV exports. Applied settings are remembered across
             page reloads.
@@ -167,7 +167,7 @@ export function CsvExportSettingsDialog({
 
           <div class={styles.csv_date_settings}>
             <div>
-              <label for="csvDateFormat">Date format</label>
+              <label for="csvDateFormat">Date and time format</label>
               <p>
                 Human-readable timestamps use your browser's local time zone ({getBrowserTimeZone()}
                 ). Date-only values remain date-only.

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,6 +1,7 @@
-import { createSignal, onCleanup, onMount, Show, type Accessor, type Setter } from 'solid-js'
+import { onCleanup, onMount, type Accessor, type Setter } from 'solid-js'
 import { isKeylessProduct } from '../claim-report'
 import { hasRedeemedKeyValue, serializeRedeemedKeyValue } from '../redeemed-key'
+import { captureProductReference, resolveProductReference } from '../product-reference'
 import {
   getRegionCountryCodes,
   hasRegionRestrictions,
@@ -25,60 +26,33 @@ import DataTable, { type Api } from 'datatables.net-dt'
 import { hm } from '@violentmonkey/dom'
 // @ts-expect-error missing types
 import styles from '../style.module.css'
-import { KeylessRedemptionConfirmation } from './BulkRevealDialogs'
-
-type PendingKeylessRedemption = {
-  product: Product
-  gift: boolean
-  resolve: (confirmed: boolean) => void
-}
 
 const PAGING_POSITION_TOLERANCE = 0.5
 
 export function Table({
   products,
+  latestProducts,
+  currentDt,
   steamId,
   setDt,
+  waitForProductRefresh,
+  requestKeylessConfirmation,
+  finishKeylessRedemption,
   initialState,
   onStateRestored,
 }: {
   products: Product[]
+  latestProducts: Accessor<Product[] | undefined>
+  currentDt: Accessor<Api<Product> | null>
   steamId: Accessor<string | null>
   setDt: Setter<Api<Product> | null>
+  waitForProductRefresh: () => Promise<void>
+  requestKeylessConfirmation: (product: Product, gift: boolean) => Promise<boolean>
+  finishKeylessRedemption: () => void
   initialState?: TableState | null
   onStateRestored?: () => void
 }) {
   let tableRef!: HTMLTableElement
-  const [pendingKeylessRedemption, setPendingKeylessRedemption] =
-    createSignal<PendingKeylessRedemption | null>(null)
-  const [keylessRedemptionProcessing, setKeylessRedemptionProcessing] = createSignal(false)
-
-  const requestKeylessConfirmation = (product: Product, gift: boolean): Promise<boolean> => {
-    if (pendingKeylessRedemption()) return Promise.resolve(false)
-
-    setKeylessRedemptionProcessing(false)
-    return new Promise((resolve) => setPendingKeylessRedemption({ product, gift, resolve }))
-  }
-
-  const cancelKeylessRedemption = (): void => {
-    if (keylessRedemptionProcessing()) return
-
-    const pending = pendingKeylessRedemption()
-    if (!pending) return
-
-    setPendingKeylessRedemption(null)
-    pending.resolve(false)
-  }
-
-  const confirmKeylessRedemption = (): void => {
-    const pending = pendingKeylessRedemption()
-    if (!pending || keylessRedemptionProcessing()) return
-
-    setKeylessRedemptionProcessing(true)
-    pending.resolve(true)
-  }
-
-  onCleanup(() => pendingKeylessRedemption()?.resolve(false))
 
   onMount(() => {
     console.debug('Mounting table with', products.length, 'products')
@@ -646,16 +620,40 @@ export function Table({
 
     const revealProduct = async (row: Product, gift: boolean): Promise<void> => {
       const keyless = isKeylessProduct(row)
-      if (keyless && !(await requestKeylessConfirmation(row, gift))) return
+      let keylessConfirmed = false
 
       try {
-        if (hasRedeemedKeyValue(row.redeemed_key_val) || row.is_gift) return
+        const reference = captureProductReference(products, row)
 
-        const value = await redeem(row, gift)
-        row.redeemed_key_val = value
-        row.type = gift ? 'Gift' : 'Key'
-        row.is_gift = gift
-        dt.rows((_index, product) => product === row)
+        if (keyless) {
+          keylessConfirmed = await requestKeylessConfirmation(row, gift)
+          if (!keylessConfirmed) return
+        }
+
+        // A Steam notice can schedule a refresh just before a reveal or while a keyless
+        // confirmation is open. Let it finish, then operate on the current product object.
+        await waitForProductRefresh()
+        const beforeRedeem = latestProducts()
+        if (!beforeRedeem) throw new Error('Product data is unavailable. Please try again.')
+
+        const currentProduct = resolveProductReference(reference, beforeRedeem)
+        if (hasRedeemedKeyValue(currentProduct.redeemed_key_val) || currentProduct.is_gift) return
+
+        const value = await redeem(currentProduct, gift)
+
+        // The table can be rebuilt while Humble is processing the request. Re-resolve the product
+        // before mutating/invalidation so we never write to a stale row or destroyed DataTable.
+        await waitForProductRefresh()
+        const afterRedeem = latestProducts()
+        if (!afterRedeem) throw new Error('Product data is unavailable. Please try again.')
+
+        const latestProduct = resolveProductReference(reference, afterRedeem)
+        latestProduct.redeemed_key_val = value
+        latestProduct.type = gift ? 'Gift' : 'Key'
+        latestProduct.is_gift = gift
+
+        currentDt()
+          ?.rows((_index, product) => product === latestProduct)
           .invalidate('data')
           .draw(false)
 
@@ -671,10 +669,7 @@ export function Table({
       } catch (error) {
         showErrorToast(error)
       } finally {
-        if (keyless) {
-          setPendingKeylessRedemption(null)
-          setKeylessRedemptionProcessing(false)
-        }
+        if (keylessConfirmed) finishKeylessRedemption()
       }
     }
 
@@ -852,30 +847,49 @@ export function Table({
                       const target = e.currentTarget as HTMLButtonElement
                       target.disabled = true
                       target.innerHTML = '<i class="hb hb-spin hb-spinner"></i>'
+                      const appId = row.steam_app_id!
+                      const steamIdAtRequest = steamId()
                       try {
-                        const result = await fetchRedeemedDate(row.steam_app_id!)
+                        const result = await fetchRedeemedDate(appId)
                         if (result) {
-                          const appId = row.steam_app_id!
-
-                          setRedeemedDate(appId, result, steamId())
-                          clearSteamSupportNotice(appId)
-
-                          for (const product of products) {
-                            if (product.steam_app_id === appId) {
-                              product.redeemed_date = result
-                            }
+                          if (steamId() !== steamIdAtRequest) {
+                            throw new Error(
+                              'Steam account changed while fetching. Please try again.'
+                            )
                           }
 
-                          dt.rows((_idx, product) => product.steam_app_id === appId)
+                          setRedeemedDate(appId, result, steamIdAtRequest)
+                          clearSteamSupportNotice(appId)
+
+                          // A product refresh may replace the table while Steam Support is loading.
+                          // Wait for it to settle, then update the current product objects/table.
+                          await waitForProductRefresh()
+                          if (steamId() !== steamIdAtRequest) {
+                            throw new Error(
+                              'Steam account changed while fetching. Please try again.'
+                            )
+                          }
+
+                          const currentProducts = latestProducts()
+                          if (!currentProducts) {
+                            throw new Error('Product data is unavailable. Please try again.')
+                          }
+
+                          for (const product of currentProducts) {
+                            if (product.steam_app_id === appId) product.redeemed_date = result
+                          }
+
+                          currentDt()
+                            ?.rows((_idx, product) => product.steam_app_id === appId)
                             .invalidate('data')
                             .draw('page')
                         } else {
-                          showSteamSupportNotice(row.steam_app_id!)
+                          showSteamSupportNotice(appId)
                           target.disabled = false
                           target.innerHTML = '<i class="hb hb-clock"></i>'
                         }
                       } catch (err) {
-                        showSteamSupportNotice(row.steam_app_id!)
+                        showSteamSupportNotice(appId)
                         showErrorToast(err, 'Failed to fetch')
                         target.disabled = false
                         target.innerHTML = '<i class="hb hb-clock"></i>'
@@ -1282,20 +1296,5 @@ export function Table({
     })
   })
   console.debug('Table Loaded')
-  return (
-    <>
-      <table ref={tableRef} id="hb_extractor-table" class="display compact"></table>
-      <Show when={pendingKeylessRedemption()} keyed>
-        {(pending) => (
-          <KeylessRedemptionConfirmation
-            product={pending.product}
-            gift={pending.gift}
-            processing={keylessRedemptionProcessing}
-            onCancel={cancelKeylessRedemption}
-            onConfirm={confirmKeylessRedemption}
-          />
-        )}
-      </Show>
-    </>
-  )
+  return <table ref={tableRef} id="hb_extractor-table" class="display compact"></table>
 }

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1176,6 +1176,9 @@ export function Table({
     dt.on('draw', clearPagingHeightReservationForNonPagingDraw)
     dt.on('draw', restorePagingTop)
     dt.on('draw', syncPageJump)
+    // The table can initialize while the exporter is hidden. Re-measure paging geometry when
+    // DataTables recalculates its layout after the table becomes visible.
+    dt.on('column-sizing', syncPageJump)
     dt.on('draw', closeRegionPopover)
     window.addEventListener('resize', resetPagingPositionStability)
 
@@ -1275,6 +1278,7 @@ export function Table({
       dt.off('draw', clearPagingHeightReservationForNonPagingDraw)
       dt.off('draw', restorePagingTop)
       dt.off('draw', syncPageJump)
+      dt.off('column-sizing', syncPageJump)
       dt.off('draw', closeRegionPopover)
 
       cancelPagingRestore()

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -555,7 +555,8 @@ export function Table({
       const pageNumberCharacters = pageDigits + Math.floor((pageDigits - 1) / 3)
 
       pageJumpInput.maxLength = pageDigits
-      pageJumpInput.style.width = `${Math.max(4, pageDigits + 2)}ch`
+      // Include the input padding and borders plus a small buffer for fractional-pixel text metrics.
+      pageJumpInput.style.width = `calc(${pageDigits}ch + 1.2em + 4px)`
       pageJumpTotal.textContent = String(info.pages)
 
       const pageControls = pageJump.parentElement

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -648,6 +648,11 @@ export function Table({
             [10, 25, 50, 100, 500, 1000, 5000, -1],
             [10, 25, 50, 100, 500, '1,000', '5,000', 'All'],
           ],
+          language: {
+            searchBuilder: {
+              data: 'Field',
+            },
+          },
           columnDefs: [
             {
               targets: [7, 9],
@@ -1110,9 +1115,35 @@ export function Table({
       }
     }
 
+    const handleSearchBuilderChange = (event: Event): void => {
+      refreshWarnings()
+
+      const target = event.target
+      if (!(target instanceof HTMLSelectElement) || !target.classList.contains('dtsb-data')) return
+
+      const criterion = target.closest('.dtsb-criteria')
+      if (!criterion || !event.isTrusted) return
+
+      // SearchBuilder resets its internal condition/value state when the field changes, but v1.8.2
+      // can leave old multi-value controls in the DOM. Run after its handler and remove any stale
+      // controls only when the freshly populated condition selector is still at its placeholder.
+      queueMicrotask(() => {
+        if (!criterion.isConnected) return
+
+        const condition = criterion.querySelector<HTMLSelectElement>('select.dtsb-condition')
+        const valueContainer = criterion.querySelector<HTMLElement>('.dtsb-inputCont')
+        if (!condition || condition.value !== '' || !valueContainer) return
+
+        const jquery = DataTable.use('jq') as (element: HTMLElement) => SearchBuilderValue
+        for (const child of Array.from(valueContainer.children)) {
+          jquery(child as HTMLElement).remove()
+        }
+      })
+    }
+
     refreshWarnings()
 
-    searchBuilderRoot?.addEventListener('change', refreshWarnings)
+    searchBuilderRoot?.addEventListener('change', handleSearchBuilderChange)
 
     const observer = searchBuilderRoot ? new MutationObserver(refreshWarnings) : null
 
@@ -1137,7 +1168,7 @@ export function Table({
       cancelRegionPopoverHide()
       regionPopover.remove()
 
-      searchBuilderRoot?.removeEventListener('change', refreshWarnings)
+      searchBuilderRoot?.removeEventListener('change', handleSearchBuilderChange)
       observer?.disconnect()
       for (const warning of warnings) warning.element.remove()
 

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -567,15 +567,51 @@ export function Table({
     pageJump.className = styles.page_jump
     pageJump.append('Jump to', pageJumpInput, 'of', pageJumpTotal)
 
+    let measuredPagingNumberCharacters = 0
+
     const syncPageJump = (): void => {
       const info = dt.page.info()
       const hasPages = info.pages > 0
 
       pageJumpInput.disabled = !hasPages
       pageJumpInput.value = hasPages ? String(info.page + 1) : ''
-      pageJumpInput.maxLength = Math.max(1, String(info.pages).length)
-      pageJumpInput.style.width = `${Math.max(4, String(info.pages).length + 2)}ch`
+      const pageDigits = Math.max(1, String(info.pages).length)
+      const pageNumberCharacters = pageDigits + Math.floor((pageDigits - 1) / 3)
+
+      pageJumpInput.maxLength = pageDigits
+      pageJumpInput.style.width = `${Math.max(4, pageDigits + 2)}ch`
       pageJumpTotal.textContent = String(info.pages)
+
+      const pageControls = pageJump.parentElement
+      if (!pageControls) return
+
+      pageControls.style.setProperty(
+        '--hb-paging-number-content-width',
+        `${pageNumberCharacters}ch`
+      )
+
+      if (pageNumberCharacters === measuredPagingNumberCharacters) return
+
+      // DataTables renders page numbers as buttons and ellipses as spans, which can resolve
+      // relative widths differently. Measure a real number button so every slot occupies the same
+      // space and the surrounding navigation controls stay fixed while paging.
+      pageControls.style.removeProperty('--hb-paging-number-slot-width')
+      pageControls.style.removeProperty('--hb-paging-number-slot-margin-left')
+
+      const pageNumberButton = pageControls.querySelector<HTMLElement>(
+        '.dt-paging .dt-paging-button:not(.first):not(.previous):not(.next):not(.last)'
+      )
+      if (!pageNumberButton) return
+
+      const width = pageNumberButton.getBoundingClientRect().width
+      if (width <= 0) return
+
+      pageControls.style.setProperty('--hb-paging-number-slot-width', `${width}px`)
+      pageControls.style.setProperty(
+        '--hb-paging-number-slot-margin-left',
+        window.getComputedStyle(pageNumberButton).marginLeft
+      )
+      measuredPagingNumberCharacters = pageNumberCharacters
     }
 
     const jumpToPage = (): void => {

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -33,6 +33,8 @@ type PendingKeylessRedemption = {
   resolve: (confirmed: boolean) => void
 }
 
+const PAGING_POSITION_TOLERANCE = 0.5
+
 export function Table({
   products,
   steamId,
@@ -1068,36 +1070,100 @@ export function Table({
     }
 
     const container = dt.table().container() as HTMLElement
+    const tableLayoutCell = container.querySelector<HTMLElement>(
+      '.dt-layout-table > .dt-layout-cell'
+    )
 
     let pagingTop: number | null = null
+    let pagingRestoreFrame: number | null = null
+
+    const clearPagingHeightReservation = (): void => {
+      tableLayoutCell?.style.removeProperty('min-height')
+    }
+
+    const cancelPagingRestore = (): void => {
+      if (pagingRestoreFrame == null) return
+
+      cancelAnimationFrame(pagingRestoreFrame)
+      pagingRestoreFrame = null
+    }
+
+    const resetPagingPositionStability = (): void => {
+      pagingTop = null
+      cancelPagingRestore()
+      clearPagingHeightReservation()
+    }
 
     const getPaging = () => container.querySelector<HTMLElement>('.dt-paging')
 
-    const rememberPagingTop = () => {
-      const rect = getPaging()?.getBoundingClientRect()
+    const rememberPagingTop = (): void => {
+      cancelPagingRestore()
 
+      const rect = getPaging()?.getBoundingClientRect()
       pagingTop = rect && rect.bottom > 0 && rect.top < window.innerHeight ? rect.top : null
+
+      // Each page transition starts from the table's natural height. Any extra height retained from
+      // the previous transition is only a fallback for a scroll-boundary shortfall.
+      clearPagingHeightReservation()
     }
 
-    const restorePagingTop = () => {
+    const clearPagingHeightReservationForNonPagingDraw = (): void => {
+      if (pagingTop != null) return
+
+      cancelPagingRestore()
+      clearPagingHeightReservation()
+    }
+
+    const restorePagingTop = (): void => {
       if (pagingTop == null) return
 
       const previousTop = pagingTop
       pagingTop = null
 
-      requestAnimationFrame(() => {
-        const nextTop = getPaging()?.getBoundingClientRect().top
-        if (nextTop != null) {
-          window.scrollBy({ top: nextTop - previousTop, behavior: 'auto' })
+      cancelPagingRestore()
+      pagingRestoreFrame = requestAnimationFrame(() => {
+        pagingRestoreFrame = null
+
+        const paging = getPaging()
+        if (!paging) return
+
+        const nextTop = paging.getBoundingClientRect().top
+        const scrollDelta = nextTop - previousTop
+
+        if (Math.abs(scrollDelta) > PAGING_POSITION_TOLERANCE) {
+          window.scrollBy({ top: scrollDelta, behavior: 'auto' })
         }
+
+        if (!tableLayoutCell) return
+
+        // Scrolling can be clamped at the top of the document when a shorter page replaces a
+        // taller one. Reserve only that uncompensated remainder below the table so the paging
+        // controls stay at the same viewport position without constraining any row content.
+        const residual = previousTop - paging.getBoundingClientRect().top
+        if (residual <= PAGING_POSITION_TOLERANCE) return
+
+        const naturalHeight = tableLayoutCell.getBoundingClientRect().height
+        tableLayoutCell.style.minHeight = `${naturalHeight + residual}px`
+
+        // Account for box-model/subpixel differences so the fallback remains exact rather than
+        // accumulating a small error across repeated transitions.
+        const correction = previousTop - paging.getBoundingClientRect().top
+        if (Math.abs(correction) <= PAGING_POSITION_TOLERANCE) return
+
+        const currentMinHeight = Number.parseFloat(tableLayoutCell.style.minHeight)
+        if (!Number.isFinite(currentMinHeight)) return
+
+        tableLayoutCell.style.minHeight = `${Math.max(naturalHeight, currentMinHeight + correction)}px`
       })
     }
 
     syncPageJump()
     dt.on('page', rememberPagingTop)
+    dt.on('draw', clearPagingHeightReservationForNonPagingDraw)
     dt.on('draw', restorePagingTop)
     dt.on('draw', syncPageJump)
     dt.on('draw', closeRegionPopover)
+    window.addEventListener('resize', resetPagingPositionStability)
 
     // Warnings when selecting certain column filters
 
@@ -1192,10 +1258,13 @@ export function Table({
 
     onCleanup(() => {
       dt.off('page', rememberPagingTop)
+      dt.off('draw', clearPagingHeightReservationForNonPagingDraw)
       dt.off('draw', restorePagingTop)
       dt.off('draw', syncPageJump)
       dt.off('draw', closeRegionPopover)
 
+      cancelPagingRestore()
+      window.removeEventListener('resize', resetPagingPositionStability)
       window.removeEventListener('resize', closeRegionPopover)
       window.removeEventListener('scroll', closeRegionPopover, true)
       regionPopover.removeEventListener('mouseenter', cancelRegionPopoverHide)

--- a/src/csv-export.ts
+++ b/src/csv-export.ts
@@ -1,0 +1,374 @@
+import { serializeRedeemedKeyValue } from './redeemed-key'
+import type { Product } from './util'
+
+export type CsvDateFormat = 'iso' | 'human'
+
+export type CsvColumnId =
+  | 'machine_name'
+  | 'category'
+  | 'category_id'
+  | 'category_human_name'
+  | 'human_name'
+  | 'key_type'
+  | 'direct_redeem'
+  | 'type'
+  | 'redeemed_key_val'
+  | 'is_gift'
+  | 'is_expired'
+  | 'expiry_date'
+  | 'steam_app_id'
+  | 'created'
+  | 'keyindex'
+  | 'owned'
+  | 'redeemed_status'
+  | 'redeemed_date'
+  | 'exclusive_countries'
+  | 'disallowed_countries'
+
+export type CsvExportPreferences = {
+  /** null means use the current default set, including default columns added in future versions. */
+  columnIds: CsvColumnId[] | null
+  dateFormat: CsvDateFormat
+}
+
+type CsvDateKind = 'date-only' | 'date-time' | 'expiry'
+
+type CsvColumnDefinition = {
+  id: CsvColumnId
+  label: string
+  header: string
+  getValue: (product: Product) => unknown
+  dateKind?: CsvDateKind
+}
+
+const CSV_EXPORT_SETTINGS_KEY = 'hb-key-exporter:csv-export-preferences'
+const CSV_EXPORT_SETTINGS_VERSION = 1
+
+export const DEFAULT_CSV_EXPORT_PREFERENCES: Readonly<CsvExportPreferences> = Object.freeze({
+  columnIds: null,
+  dateFormat: 'iso',
+})
+
+const humanDateOnlyFormatter = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+  timeZone: 'UTC',
+})
+
+const humanDateTimeFormatter = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: true,
+  timeZoneName: 'short',
+})
+
+const csvColumnDefinitions: readonly CsvColumnDefinition[] = [
+  {
+    id: 'machine_name',
+    label: 'Machine name',
+    header: 'machine_name',
+    getValue: (product) => product.machine_name,
+  },
+  {
+    id: 'category',
+    label: 'Category',
+    header: 'category',
+    getValue: (product) => product.category,
+  },
+  {
+    id: 'category_id',
+    label: 'Bundle ID',
+    header: 'category_id',
+    getValue: (product) => product.category_id,
+  },
+  {
+    id: 'category_human_name',
+    label: 'Bundle name',
+    header: 'category_human_name',
+    getValue: (product) => product.category_human_name,
+  },
+  {
+    id: 'human_name',
+    label: 'Name',
+    header: 'human_name',
+    getValue: (product) => product.human_name,
+  },
+  {
+    id: 'key_type',
+    label: 'Key type',
+    header: 'key_type',
+    getValue: (product) => product.key_type,
+  },
+  {
+    id: 'direct_redeem',
+    label: 'Direct redeem',
+    header: 'direct_redeem',
+    getValue: (product) => product.direct_redeem,
+  },
+  { id: 'type', label: 'Format', header: 'type', getValue: (product) => product.type },
+  {
+    id: 'redeemed_key_val',
+    label: 'Key / redemption value',
+    header: 'redeemed_key_val',
+    getValue: (product) =>
+      product.redeemed_key_val ? serializeRedeemedKeyValue(product.redeemed_key_val) : '',
+  },
+  { id: 'is_gift', label: 'Gift', header: 'is_gift', getValue: (product) => product.is_gift },
+  {
+    id: 'is_expired',
+    label: 'Expired',
+    header: 'is_expired',
+    getValue: (product) => product.is_expired,
+  },
+  {
+    id: 'expiry_date',
+    label: 'Expiration date',
+    header: 'expiry_date',
+    getValue: (product) => product.expiry_date ?? '',
+    dateKind: 'expiry',
+  },
+  {
+    id: 'steam_app_id',
+    label: 'Steam app ID',
+    header: 'steam_app_id',
+    getValue: (product) => product.steam_app_id ?? '',
+  },
+  {
+    id: 'created',
+    label: 'Purchased',
+    header: 'created',
+    getValue: (product) => product.created,
+    dateKind: 'date-time',
+  },
+  {
+    id: 'keyindex',
+    label: 'Key index',
+    header: 'keyindex',
+    getValue: (product) => product.keyindex ?? '',
+  },
+  { id: 'owned', label: 'Owned', header: 'owned', getValue: (product) => product.owned },
+  {
+    id: 'redeemed_status',
+    label: 'Redeemed status',
+    header: 'redeemed_status',
+    getValue: (product) => product.redeemed_date?.label ?? '',
+  },
+  {
+    id: 'redeemed_date',
+    label: 'Redeemed date',
+    header: 'redeemed_date',
+    getValue: (product) => product.redeemed_date?.iso ?? '',
+    dateKind: 'date-only',
+  },
+  {
+    id: 'exclusive_countries',
+    label: 'Exclusive countries',
+    header: 'exclusive_countries',
+    getValue: (product) => product.exclusive_countries.join(';'),
+  },
+  {
+    id: 'disallowed_countries',
+    label: 'Disallowed countries',
+    header: 'disallowed_countries',
+    getValue: (product) => product.disallowed_countries.join(';'),
+  },
+]
+
+export const CSV_COLUMNS: readonly Readonly<Pick<CsvColumnDefinition, 'id' | 'label'>>[] =
+  csvColumnDefinitions.map(({ id, label }) => Object.freeze({ id, label }))
+
+export const DEFAULT_CSV_COLUMN_IDS: readonly CsvColumnId[] = csvColumnDefinitions.map(
+  ({ id }) => id
+)
+
+const csvColumnIds = new Set<CsvColumnId>(DEFAULT_CSV_COLUMN_IDS)
+const csvColumnById = new Map(csvColumnDefinitions.map((definition) => [definition.id, definition]))
+
+const tableColumnCsvIds: readonly (readonly CsvColumnId[])[] = [
+  ['key_type'],
+  ['human_name'],
+  ['category'],
+  ['category_human_name'],
+  ['type'],
+  ['redeemed_key_val', 'is_gift'],
+  ['owned'],
+  ['created'],
+  ['redeemed_status', 'redeemed_date'],
+  ['expiry_date'],
+  ['exclusive_countries', 'disallowed_countries'],
+  [],
+]
+
+const isCsvColumnId = (value: unknown): value is CsvColumnId =>
+  typeof value === 'string' && csvColumnIds.has(value as CsvColumnId)
+
+const normalizeColumnIds = (values: readonly unknown[]): CsvColumnId[] => {
+  const selected = new Set(values.filter(isCsvColumnId))
+  return DEFAULT_CSV_COLUMN_IDS.filter((id) => selected.has(id))
+}
+
+const isCsvDateFormat = (value: unknown): value is CsvDateFormat =>
+  value === 'iso' || value === 'human'
+
+const cloneDefaultPreferences = (): CsvExportPreferences => ({
+  columnIds: null,
+  dateFormat: DEFAULT_CSV_EXPORT_PREFERENCES.dateFormat,
+})
+
+export const normalizeCsvExportPreferences = (value: unknown): CsvExportPreferences => {
+  if (!value || typeof value !== 'object') return cloneDefaultPreferences()
+
+  const candidate = value as {
+    version?: unknown
+    columnIds?: unknown
+    dateFormat?: unknown
+  }
+
+  if (candidate.version !== CSV_EXPORT_SETTINGS_VERSION) return cloneDefaultPreferences()
+
+  let columnIds: CsvColumnId[] | null = null
+  if (candidate.columnIds !== null) {
+    if (!Array.isArray(candidate.columnIds)) return cloneDefaultPreferences()
+    const normalized = normalizeColumnIds(candidate.columnIds)
+    if (!normalized.length) return cloneDefaultPreferences()
+    columnIds = normalized
+  }
+
+  return {
+    columnIds,
+    dateFormat: isCsvDateFormat(candidate.dateFormat) ? candidate.dateFormat : 'iso',
+  }
+}
+
+export const loadCsvExportPreferences = (): CsvExportPreferences => {
+  try {
+    return normalizeCsvExportPreferences(GM_getValue(CSV_EXPORT_SETTINGS_KEY, null))
+  } catch (error) {
+    console.warn('Failed to load CSV export preferences:', error)
+    return cloneDefaultPreferences()
+  }
+}
+
+export const saveCsvExportPreferences = (preferences: CsvExportPreferences): void => {
+  GM_setValue(CSV_EXPORT_SETTINGS_KEY, {
+    version: CSV_EXPORT_SETTINGS_VERSION,
+    columnIds: preferences.columnIds,
+    dateFormat: preferences.dateFormat,
+  })
+}
+
+export const resolveCsvColumnIds = (preferences: CsvExportPreferences): CsvColumnId[] =>
+  preferences.columnIds ? [...preferences.columnIds] : [...DEFAULT_CSV_COLUMN_IDS]
+
+export const getVisibleCsvColumnIds = (visibleTableColumns: readonly boolean[]): CsvColumnId[] => {
+  const selected = new Set<CsvColumnId>()
+
+  visibleTableColumns.forEach((visible, index) => {
+    if (!visible) return
+    for (const id of tableColumnCsvIds[index] ?? []) selected.add(id)
+  })
+
+  return DEFAULT_CSV_COLUMN_IDS.filter((id) => selected.has(id))
+}
+
+export const getBrowserTimeZone = (): string =>
+  Intl.DateTimeFormat().resolvedOptions().timeZone || 'local time'
+
+const escapeCsvField = (value: string, delimiter: string): string => {
+  const needsQuotes =
+    value.includes('"') ||
+    value.includes('\n') ||
+    value.includes('\r') ||
+    (delimiter ? value.includes(delimiter) : false) ||
+    value.trim() !== value
+
+  return needsQuotes ? `"${value.replace(/"/g, '""')}"` : value
+}
+
+const serializeField = (value: unknown): string => {
+  if (value == null) return ''
+  if (typeof value === 'object') return JSON.stringify(value) ?? ''
+  return String(value)
+}
+
+const formatDateOnly = (value: string): string => {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (!match) return value
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const date = new Date(Date.UTC(year, month - 1, day))
+
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return value
+  }
+
+  return humanDateOnlyFormatter.format(date)
+}
+
+const formatHumanDate = (value: unknown, kind: CsvDateKind): string => {
+  const serialized = serializeField(value)
+  if (!serialized) return ''
+
+  if (kind === 'date-only') return formatDateOnly(serialized)
+  if (kind === 'expiry' && /^\d{4}-\d{2}-\d{2}T00:00:00\.000Z$/.test(serialized)) {
+    return formatDateOnly(serialized.slice(0, 10))
+  }
+
+  const date = new Date(serialized)
+  return Number.isNaN(date.getTime()) ? serialized : humanDateTimeFormatter.format(date)
+}
+
+export const getCsvColumnHeader = (id: CsvColumnId): string => csvColumnById.get(id)?.header ?? id
+
+const getColumnValue = (
+  product: Product,
+  definition: CsvColumnDefinition,
+  dateFormat: CsvDateFormat
+): string => {
+  const value = definition.getValue(product)
+  if (dateFormat === 'human' && definition.dateKind) {
+    return formatHumanDate(value, definition.dateKind)
+  }
+  return serializeField(value)
+}
+
+export const exportCSV = (
+  products: Product[],
+  delimiter: string,
+  preferences: CsvExportPreferences
+): string => {
+  if (!products.length) return ''
+
+  const selectedIds = resolveCsvColumnIds(preferences)
+  const definitions = selectedIds.flatMap((id) => {
+    const definition = csvColumnById.get(id)
+    return definition ? [definition] : []
+  })
+  if (!definitions.length) return ''
+
+  const rows = [
+    definitions
+      .map((definition) => escapeCsvField(getCsvColumnHeader(definition.id), delimiter))
+      .join(delimiter),
+    ...products.map((product) =>
+      definitions
+        .map((definition) =>
+          escapeCsvField(getColumnValue(product, definition, preferences.dateFormat), delimiter)
+        )
+        .join(delimiter)
+    ),
+  ]
+
+  return `${rows.join('\n')}\n`
+}

--- a/src/download.ts
+++ b/src/download.ts
@@ -1,0 +1,45 @@
+const padTimestampPart = (value: number): string => String(value).padStart(2, '0')
+
+export const formatLocalTimestamp = (date: Date): string =>
+  [
+    date.getFullYear(),
+    padTimestampPart(date.getMonth() + 1),
+    padTimestampPart(date.getDate()),
+  ].join('') +
+  '-' +
+  [
+    padTimestampPart(date.getHours()),
+    padTimestampPart(date.getMinutes()),
+    padTimestampPart(date.getSeconds()),
+  ].join('')
+
+export const downloadTextFile = (
+  text: string,
+  filename: string,
+  mimeType = 'text/plain;charset=utf-8'
+): void => {
+  let url: string | null = null
+
+  try {
+    url = URL.createObjectURL(new Blob([text], { type: mimeType }))
+
+    const link = document.createElement('a')
+    link.href = url
+    link.download = filename
+    link.style.display = 'none'
+    document.body.append(link)
+
+    try {
+      link.click()
+    } finally {
+      link.remove()
+    }
+
+    const objectUrl = url
+    window.setTimeout(() => URL.revokeObjectURL(objectUrl), 1000)
+    url = null
+  } catch (error) {
+    if (url) URL.revokeObjectURL(url)
+    throw error
+  }
+}

--- a/src/meta.js
+++ b/src/meta.js
@@ -16,7 +16,9 @@
 // @homepageURL https://github.com/MrMarble/hb-key-exporter
 // @grant       GM_addStyle
 // @grant       GM_getResourceText
+// @grant       GM_getValue
 // @grant       GM_setClipboard
+// @grant       GM_setValue
 // @grant       GM_xmlhttpRequest
 // @connect     store.steampowered.com
 // @connect     help.steampowered.com

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -11,6 +11,8 @@ const TABBABLE_SELECTOR = [
   '[tabindex]',
 ].join(',')
 
+const MODAL_SCROLL_BODY_SELECTOR = '[data-modal-scroll-body]'
+
 const activeDialogs = new Set<HTMLElement>()
 let modalSessionRestoreTarget: HTMLElement | null = null
 
@@ -45,6 +47,101 @@ const canRestoreFocus = (target: HTMLElement): boolean =>
 
 const isInsideActiveDialog = (target: HTMLElement): boolean =>
   Array.from(activeDialogs).some((dialog) => dialog.contains(target))
+
+const getEventScrollBody = (event: Event): HTMLElement | undefined =>
+  event
+    .composedPath()
+    .find(
+      (target): target is HTMLElement =>
+        target instanceof HTMLElement &&
+        target.matches(MODAL_SCROLL_BODY_SELECTOR) &&
+        isInsideActiveDialog(target)
+    )
+
+const canScrollBody = (scrollBody: HTMLElement, deltaY: number): boolean => {
+  if (deltaY < 0) return scrollBody.scrollTop > 0
+  if (deltaY > 0) {
+    return scrollBody.scrollTop + scrollBody.clientHeight < scrollBody.scrollHeight - 1
+  }
+  return false
+}
+
+const preventBackgroundWheel = (event: WheelEvent): void => {
+  if (event.ctrlKey) return
+
+  const scrollBody = getEventScrollBody(event)
+  if (!scrollBody || !canScrollBody(scrollBody, event.deltaY)) event.preventDefault()
+}
+
+let lastTouchY: number | null = null
+let touchScrollBody: HTMLElement | null = null
+
+const trackTouchStart = (event: TouchEvent): void => {
+  if (event.touches.length !== 1) {
+    lastTouchY = null
+    touchScrollBody = null
+    return
+  }
+
+  lastTouchY = event.touches[0].clientY
+  touchScrollBody = getEventScrollBody(event) ?? null
+}
+
+const preventBackgroundTouchMove = (event: TouchEvent): void => {
+  if (event.touches.length !== 1) {
+    lastTouchY = null
+    touchScrollBody = null
+    return
+  }
+
+  const currentY = event.touches[0].clientY
+  const previousY = lastTouchY
+  lastTouchY = currentY
+
+  if (!touchScrollBody) {
+    event.preventDefault()
+    return
+  }
+
+  if (previousY !== null && !canScrollBody(touchScrollBody, previousY - currentY)) {
+    event.preventDefault()
+  }
+}
+
+const trackTouchEnd = (event: TouchEvent): void => {
+  if (event.touches.length === 1) {
+    lastTouchY = event.touches[0].clientY
+    return
+  }
+
+  lastTouchY = null
+  touchScrollBody = null
+}
+
+const clearTouchTracking = (): void => {
+  lastTouchY = null
+  touchScrollBody = null
+}
+
+const enableBackgroundScrollGuard = (): void => {
+  document.addEventListener('wheel', preventBackgroundWheel, { capture: true, passive: false })
+  document.addEventListener('touchstart', trackTouchStart, { capture: true, passive: true })
+  document.addEventListener('touchmove', preventBackgroundTouchMove, {
+    capture: true,
+    passive: false,
+  })
+  document.addEventListener('touchend', trackTouchEnd, true)
+  document.addEventListener('touchcancel', clearTouchTracking, true)
+}
+
+const disableBackgroundScrollGuard = (): void => {
+  document.removeEventListener('wheel', preventBackgroundWheel, true)
+  document.removeEventListener('touchstart', trackTouchStart, true)
+  document.removeEventListener('touchmove', preventBackgroundTouchMove, true)
+  document.removeEventListener('touchend', trackTouchEnd, true)
+  document.removeEventListener('touchcancel', clearTouchTracking, true)
+  clearTouchTracking()
+}
 
 export const useModalBehavior = ({
   dialog,
@@ -104,11 +201,13 @@ export const useModalBehavior = ({
     mountedDialog = dialog() ?? null
     if (!mountedDialog) return
 
-    if (!activeDialogs.size && !modalSessionRestoreTarget) {
+    const isFirstDialog = !activeDialogs.size
+    if (isFirstDialog && !modalSessionRestoreTarget) {
       modalSessionRestoreTarget = restoreFocusTarget
     }
 
     activeDialogs.add(mountedDialog)
+    if (isFirstDialog) enableBackgroundScrollGuard()
     participatedInModalSession = true
     const currentDialog = mountedDialog
     queueMicrotask(() => focusDialog(currentDialog))
@@ -117,6 +216,7 @@ export const useModalBehavior = ({
   onCleanup(() => {
     if (mountedDialog) {
       activeDialogs.delete(mountedDialog)
+      if (!activeDialogs.size) disableBackgroundScrollGuard()
       mountedDialog = null
     }
 

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -1,0 +1,172 @@
+import { createEffect, onCleanup, onMount, type Accessor } from 'solid-js'
+
+const TABBABLE_SELECTOR = [
+  'a[href]',
+  'button',
+  'input',
+  'select',
+  'textarea',
+  'summary',
+  '[contenteditable="true"]',
+  '[tabindex]',
+].join(',')
+
+const activeDialogs = new Set<HTMLElement>()
+let modalSessionRestoreTarget: HTMLElement | null = null
+
+const isRendered = (element: HTMLElement): boolean => {
+  if (element.hidden || element.closest('[hidden]') || !element.getClientRects().length)
+    return false
+
+  const style = getComputedStyle(element)
+  return style.visibility !== 'hidden' && style.visibility !== 'collapse'
+}
+
+const isAvailable = (element: HTMLElement): boolean =>
+  !element.matches(':disabled') && !element.closest('[inert]')
+
+const isTabbable = (element: HTMLElement): boolean =>
+  element.tabIndex >= 0 && isAvailable(element) && isRendered(element)
+
+const getTabbableElements = (dialog: HTMLElement): HTMLElement[] =>
+  Array.from(dialog.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR)).filter(isTabbable)
+
+const focusDialog = (dialog: HTMLElement): void => {
+  const active = document.activeElement
+  if (active instanceof HTMLElement && dialog.contains(active)) return
+
+  const autofocus = dialog.querySelector<HTMLElement>('[autofocus]')
+  if (autofocus && isTabbable(autofocus)) autofocus.focus()
+  if (!dialog.contains(document.activeElement)) dialog.focus()
+}
+
+const canRestoreFocus = (target: HTMLElement): boolean =>
+  target.isConnected && isAvailable(target) && isRendered(target)
+
+const isInsideActiveDialog = (target: HTMLElement): boolean =>
+  Array.from(activeDialogs).some((dialog) => dialog.contains(target))
+
+export const useModalBehavior = ({
+  dialog,
+  onEscape,
+  escapeDisabled,
+}: {
+  dialog: Accessor<HTMLElement | undefined>
+  onEscape: () => void
+  escapeDisabled?: Accessor<boolean>
+}) => {
+  const restoreFocusTarget =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null
+  let mountedDialog: HTMLElement | null = null
+  let participatedInModalSession = false
+
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    event.stopPropagation()
+
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      if (!escapeDisabled?.()) onEscape()
+      return
+    }
+
+    if (event.key !== 'Tab') return
+
+    const currentDialog = dialog()
+    if (!currentDialog) return
+
+    const tabbable = getTabbableElements(currentDialog)
+    if (!tabbable.length) {
+      event.preventDefault()
+      currentDialog.focus()
+      return
+    }
+
+    const first = tabbable[0]
+    const last = tabbable[tabbable.length - 1]
+    const active = document.activeElement
+    const activeIndex = active instanceof HTMLElement ? tabbable.indexOf(active) : -1
+
+    if (active === currentDialog || activeIndex === -1) {
+      event.preventDefault()
+      ;(event.shiftKey ? last : first).focus()
+    } else if (event.shiftKey && active === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
+
+  const stopPropagation = (event: Event): void => event.stopPropagation()
+
+  onMount(() => {
+    mountedDialog = dialog() ?? null
+    if (!mountedDialog) return
+
+    if (!activeDialogs.size && !modalSessionRestoreTarget) {
+      modalSessionRestoreTarget = restoreFocusTarget
+    }
+
+    activeDialogs.add(mountedDialog)
+    participatedInModalSession = true
+    const currentDialog = mountedDialog
+    queueMicrotask(() => focusDialog(currentDialog))
+  })
+
+  onCleanup(() => {
+    if (mountedDialog) {
+      activeDialogs.delete(mountedDialog)
+      mountedDialog = null
+    }
+
+    if (!participatedInModalSession) return
+    requestAnimationFrame(() => {
+      if (activeDialogs.size) {
+        if (
+          restoreFocusTarget &&
+          canRestoreFocus(restoreFocusTarget) &&
+          isInsideActiveDialog(restoreFocusTarget)
+        ) {
+          restoreFocusTarget.focus({ preventScroll: true })
+          return
+        }
+
+        const active = document.activeElement
+        if (!(active instanceof HTMLElement) || !isInsideActiveDialog(active)) {
+          const fallbackDialog = Array.from(activeDialogs).pop()
+          if (fallbackDialog) focusDialog(fallbackDialog)
+        }
+        return
+      }
+
+      const sessionTarget = modalSessionRestoreTarget
+      modalSessionRestoreTarget = null
+      if (sessionTarget && canRestoreFocus(sessionTarget)) {
+        sessionTarget.focus({ preventScroll: true })
+      }
+    })
+  })
+
+  if (escapeDisabled) {
+    createEffect(() => {
+      if (!escapeDisabled()) return
+
+      queueMicrotask(() => {
+        const currentDialog = dialog()
+        if (!currentDialog) return
+
+        const active = document.activeElement
+        if (
+          !(active instanceof HTMLElement) ||
+          !currentDialog.contains(active) ||
+          (active !== currentDialog && !isTabbable(active))
+        ) {
+          currentDialog.focus()
+        }
+      })
+    })
+  }
+
+  return { handleKeyDown, stopPropagation }
+}

--- a/src/product-reference.ts
+++ b/src/product-reference.ts
@@ -1,0 +1,74 @@
+import type { Product } from './util'
+
+export type ProductReference = {
+  key: string
+  occurrence: number
+}
+
+const getProductReferenceKey = (product: Product): string =>
+  JSON.stringify([product.category_id, product.machine_name, product.keyindex ?? null])
+
+const groupProductsByReferenceKey = (products: readonly Product[]): Map<string, Product[]> => {
+  const groups = new Map<string, Product[]>()
+
+  for (const product of products) {
+    const key = getProductReferenceKey(product)
+    const group = groups.get(key)
+    if (group) group.push(product)
+    else groups.set(key, [product])
+  }
+
+  return groups
+}
+
+export const captureProductReferences = (
+  allProducts: readonly Product[],
+  selectedProducts: readonly Product[]
+): ProductReference[] => {
+  const groups = groupProductsByReferenceKey(allProducts)
+
+  return selectedProducts.map((product) => {
+    const key = getProductReferenceKey(product)
+    const group = groups.get(key)
+    if (!group?.length) {
+      throw new Error('Product data changed before the operation could start. Please try again.')
+    }
+
+    const occurrence = group.indexOf(product)
+    if (occurrence >= 0) return { key, occurrence }
+    if (group.length === 1) return { key, occurrence: 0 }
+
+    throw new Error('Product data changed before the operation could start. Please try again.')
+  })
+}
+
+export const captureProductReference = (
+  allProducts: readonly Product[],
+  product: Product
+): ProductReference => captureProductReferences(allProducts, [product])[0]
+
+export const resolveProductReferences = (
+  references: readonly ProductReference[],
+  products: readonly Product[]
+): Product[] => {
+  const groups = groupProductsByReferenceKey(products)
+
+  return references.map(({ key, occurrence }) => {
+    const product = groups.get(key)?.[occurrence]
+    if (!product) {
+      throw new Error('Product data changed while the operation was in progress. Please try again.')
+    }
+    return product
+  })
+}
+
+export const resolveProductReference = (
+  reference: ProductReference,
+  products: readonly Product[]
+): Product => resolveProductReferences([reference], products)[0]
+
+export const applyRedeemedProductState = (target: Product, source: Product): void => {
+  target.redeemed_key_val = source.redeemed_key_val
+  target.type = source.type
+  target.is_gift = source.is_gift
+}

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -459,6 +459,7 @@ tr.expired {
 .modal_body {
   min-height: 0;
   overflow-y: auto;
+  overscroll-behavior-y: contain;
   padding: 20px 22px;
 }
 

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -38,6 +38,7 @@ tr.expired {
 
 .actions {
   display: flex;
+  flex-wrap: wrap;
   justify-content: end;
   gap: 10px;
   align-items: center;
@@ -55,11 +56,28 @@ tr.expired {
   transform: translateY(0.25px);
 }
 
+.export_separator {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
 .btn {
   background-color: #e9e9ed;
   border: 1px solid #8f8f9d;
   border-radius: 5px;
   padding: 1px 4px;
+}
+
+.export_secondary_button {
+  background: #f1f3f6;
+  color: #3d434c;
+  border-color: #b8bec7;
+}
+
+.export_secondary_button:not(:disabled):hover,
+.export_secondary_button:not(:disabled):focus-visible {
+  background: #e2e5e9;
 }
 
 .row_actions {

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -595,6 +595,10 @@ tr.expired {
   border-top: 1px solid #e1e4e8;
 }
 
+.result_footer {
+  flex-wrap: wrap;
+}
+
 .modal_primary_button,
 .modal_secondary_button {
   min-width: 94px;

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -56,10 +56,25 @@ tr.expired {
   transform: translateY(0.25px);
 }
 
-.export_separator {
+.export_delimiter {
   display: inline-flex;
   align-items: center;
+  gap: 5px;
   white-space: nowrap;
+}
+
+.export_delimiter_select {
+  box-sizing: border-box;
+  width: 9.5em;
+  min-width: 0;
+}
+
+.export_custom_delimiter {
+  box-sizing: border-box;
+  width: 9ch;
+  min-width: 0;
+  padding: 4px 6px;
+  text-align: center;
 }
 
 .btn {
@@ -78,6 +93,13 @@ tr.expired {
 .export_secondary_button:not(:disabled):hover,
 .export_secondary_button:not(:disabled):focus-visible {
   background: #e2e5e9;
+}
+
+:global(.primary-button).export_secondary_button:disabled {
+  background: #e9e9ed;
+  color: #8f8f9d;
+  border-color: #c7c7cc;
+  cursor: not-allowed;
 }
 
 .row_actions {

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -136,6 +136,23 @@ tr.expired {
 
 .page_jump + :global(.dt-paging) {
   flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+}
+
+.page_jump
+  + :global(.dt-paging)
+  :global(.dt-paging-button:not(.first):not(.previous):not(.next):not(.last)),
+.page_jump + :global(.dt-paging) :global(.ellipsis) {
+  box-sizing: border-box;
+  width: var(
+    --hb-paging-number-slot-width,
+    calc(var(--hb-paging-number-content-width, 1ch) + 2em + 2px)
+  );
+}
+
+.page_jump + :global(.dt-paging) :global(.ellipsis) {
+  display: inline-block;
+  margin-left: var(--hb-paging-number-slot-margin-left, 0);
 }
 
 .page_jump_input {

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -308,6 +308,7 @@ tr.expired {
   border: 1px solid #aaa;
   border-radius: 3px;
   font: inherit;
+  font-variant-numeric: tabular-nums;
   text-align: center;
 }
 

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -100,9 +100,16 @@ tr.expired {
   white-space: nowrap;
 }
 
-:global(.dt-layout-end):has(> .page_jump) {
+:global(.dt-layout-row):has(.page_jump) {
   flex-wrap: wrap;
+  column-gap: 1em;
   row-gap: 0.5em;
+}
+
+:global(.dt-layout-end):has(> .page_jump) {
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  margin-inline-start: auto;
 }
 
 .page_jump + :global(.dt-paging) {

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -102,6 +102,150 @@ tr.expired {
   cursor: not-allowed;
 }
 
+.csv_settings_intro {
+  margin: 0 0 18px;
+  color: #4e5661;
+  font-size: 13.5px;
+  line-height: 1.5;
+}
+
+.csv_settings_section_header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 10px;
+}
+
+.csv_settings_section_header h3 {
+  margin: 0;
+  color: #353b44;
+  font-size: 14px;
+}
+
+.csv_settings_count {
+  display: block;
+  margin-top: 3px;
+  color: #69717d;
+  font-size: 12px;
+}
+
+.csv_settings_actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.csv_settings_actions button {
+  padding: 4px 8px;
+  background: #fff;
+  color: #3d434c;
+  border: 1px solid #b8bec7;
+  border-radius: 5px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.csv_settings_actions button:hover,
+.csv_settings_actions button:focus-visible {
+  background: #eef0f3;
+}
+
+.csv_column_grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.csv_column_option {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+  padding: 8px 9px;
+  background: #fafbfc;
+  border: 1px solid #dfe2e6;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.csv_column_option:hover,
+.csv_column_option:focus-within {
+  background: #f3f5f7;
+  border-color: #c8cdd4;
+}
+
+.csv_column_option input {
+  flex: 0 0 auto;
+  margin: 2px 0 0;
+}
+
+.csv_column_option span {
+  min-width: 0;
+}
+
+.csv_column_option strong,
+.csv_column_option small {
+  display: block;
+}
+
+.csv_column_option strong {
+  color: #353b44;
+  font-size: 12.5px;
+  line-height: 1.25;
+}
+
+.csv_column_option small {
+  margin-top: 2px;
+  overflow: hidden;
+  color: #737b86;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 10.5px;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.csv_date_settings {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding-top: 16px;
+  margin-top: 18px;
+  border-top: 1px solid #e1e4e8;
+}
+
+.csv_date_settings > div {
+  min-width: 0;
+}
+
+.csv_date_settings label {
+  color: #353b44;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.csv_date_settings p {
+  margin: 4px 0 0;
+  color: #69717d;
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+
+.csv_date_settings select {
+  flex: 0 0 auto;
+  width: 14em;
+  max-width: 100%;
+}
+
+.csv_settings_apply:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
 .row_actions {
   display: flex;
   gap: 2px;
@@ -669,6 +813,24 @@ tr.expired {
 }
 
 @media (max-width: 600px) {
+  .csv_settings_section_header,
+  .csv_date_settings {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .csv_settings_actions {
+    justify-content: flex-start;
+  }
+
+  .csv_column_grid {
+    grid-template-columns: 1fr;
+  }
+
+  .csv_date_settings select {
+    width: 100%;
+  }
+
   .modal_backdrop {
     align-items: flex-end;
     padding: 10px;


### PR DESCRIPTION
## Summary

This improves the Advanced Exporter's export options, CSV customization, table stability, and modal behavior.

Exports can now be copied or downloaded with timestamped, format-appropriate filenames. CSV exports support delimiter presets, configurable columns with persistent preferences, and optional human-readable date and time formatting.

Table pagination now remains stable as page numbers and page heights change, including on the first refresh after opening the exporter, and SearchBuilder field changes no longer leave stale value controls behind.

Modal dialogs now contain keyboard focus and background scrolling while preserving native scrolling within modal content. Async reveal/export and Steam Support actions also remain synchronized with product refreshes so they continue operating on current product and table data.

## Changes

### Exports and CSV

- Add separate Copy and Download actions for ASF, key, and CSV exports.
- Add a Download Log option for bulk reveal results.
- Use timestamped filenames with format-appropriate extensions and MIME types.
- Standardize exported text and logs on LF with a trailing newline.
- Add comma, tab, semicolon, pipe, and custom CSV delimiters.
- Add configurable CSV columns with Select all, Select visible, Clear all, and Reset to default actions.
- Persist CSV column and date-format preferences across reloads.
- Add optional human-readable date and time formatting while keeping date-only values date-only.
- Use stable machine-oriented CSV headers.
- Update bulk reveal confirmation and results messaging for copy and download destinations.

### Table and filtering

- Stabilize pagination controls horizontally across page changes.
- Prevent pagination controls from shifting on the first refresh after opening the exporter.
- Keep pagination at the same viewport position when page heights change.
- Prevent bottom pagination controls from crowding or wrapping awkwardly.
- Prevent page jump input values from being clipped.
- Rename SearchBuilder's `Data` selector to `Field`.
- Clear stale SearchBuilder value controls when changing fields.

### Modal and refresh behavior

- Trap keyboard focus within dialogs and restore focus without scrolling the page.
- Prevent background scrolling while dialogs are open, allowing native scrolling only within modal content.
- Keep Escape and keyboard handling contained within dialogs.
- Preserve Reveal Results focus when its non-closing backdrop is clicked so Escape dismissal continues to work.
- Keep bulk and individual reveal actions synchronized with product refreshes.
- Keep keyless confirmations and Steam Support redeemed-date updates safe when product data refreshes.