### PR TITLE
ci: validate pull request titles with commitlint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,4 +30,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
       - run: pnpm install
+      - name: Lint pull request title
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: printf '%s\n' "$PR_TITLE" | pnpm exec commitlint
       - run: pnpm run ci

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ errors.
 
 Commits must follow [Conventional Commits](https://www.conventionalcommits.org/). A
 `commit-msg` git hook runs [commitlint](https://commitlint.js.org/) and rejects
-messages that don't parse:
+messages that don't parse. Pull request titles are checked in CI as well so
+squash merges keep a valid Conventional Commit subject:
 
 ```
 feat: add CSV column chooser
@@ -63,15 +64,16 @@ fix(table): correct expiry sort order
 feat!: drop support for Node 18
 ```
 
-`feat:` bumps the minor version, `fix:` the patch version, and a `!` suffix (or a
-`BREAKING CHANGE:` footer) bumps the major. Types other than `feat`/`fix`/`perf`/
-`revert` are kept out of the changelog.
+`feat:` bumps the minor version and `fix:` the patch version. Before `1.0.0`, a
+breaking change (`!` suffix or `BREAKING CHANGE:` footer) also bumps the minor
+version; from `1.0.0` onward, it bumps the major. Types other than
+`feat`/`fix`/`perf`/`revert` are kept out of the changelog.
 
 ## Releasing
 
 Releases are automated with
 [release-please](https://github.com/googleapis/release-please-action). Merging
-conventional commits to `main` keeps a "chore: release vX.Y.Z" pull request up to
+conventional commits to `main` keeps a "chore: release X.Y.Z" pull request up to
 date with the next version and the generated `CHANGELOG.md`.
 
 Merging that release PR bumps `package.json`, updates the changelog, and pushes


### PR DESCRIPTION
## Summary

This adds CI validation for pull request titles using the existing commitlint configuration, ensuring squash-merged PRs follow Conventional Commits and can be interpreted correctly by Release Please.

It also corrects the release documentation to match the project's configured pre-1.0 versioning behavior and current Release Please PR title format.

## Changes

- Validate pull request titles with commitlint in CI.
- Pass PR titles through the environment and stdin rather than shell interpolation.
- Document PR-title validation in the development workflow.
- Correct pre-1.0 breaking-change versioning documentation.
- Correct the Release Please PR title example to match the current configuration.