### PR TITLE
fix: improve non-retryable reveal handling

### DIFF
--- a/src/claim-report.ts
+++ b/src/claim-report.ts
@@ -1,9 +1,12 @@
 export interface ClaimProduct {
+  category_id: string
   category_human_name: string
   direct_redeem: boolean
   human_name: string
   is_expired?: boolean
+  keyindex?: number
   key_type: string
+  machine_name: string
 }
 
 export type ClaimSuccess<T extends ClaimProduct = ClaimProduct> = {
@@ -13,7 +16,10 @@ export type ClaimSuccess<T extends ClaimProduct = ClaimProduct> = {
 
 export type ClaimFailure<T extends ClaimProduct = ClaimProduct> = ClaimSuccess<T> & {
   error: unknown
+  nonRetryable: boolean
 }
+
+export type ClaimSkipped<T extends ClaimProduct = ClaimProduct> = ClaimSuccess<T>
 
 export type ExportDestination = 'clipboard' | 'download'
 
@@ -28,12 +34,14 @@ export type ClaimPlan<T extends ClaimProduct = ClaimProduct> = {
   keylessCount: number
   expiredCount: number
   bundleCount: number
+  skippedCount: number
 }
 
 export type ClaimReport<T extends ClaimProduct = ClaimProduct> = {
   gift: boolean
   successes: ClaimSuccess<T>[]
   failures: ClaimFailure<T>[]
+  skipped: ClaimSkipped<T>[]
   typeCounts: ClaimTypeCount[]
   keylessCount: number
   exportDestination: ExportDestination
@@ -46,25 +54,34 @@ export type ClaimResultGroup<T extends ClaimProduct = ClaimProduct> = {
   bundleName: string
   successes: ClaimSuccess<T>[]
   failures: ClaimFailure<T>[]
+  skipped: ClaimSkipped<T>[]
 }
 
 /**
- * Products whose reveal failed permanently this session, keyed by the same
- * identity used for product references. Humble keeps reporting these as
- * non-retryable, so they are excluded from later bulk reveals rather than
- * re-requested and re-failed every time.
+ * Reveal/gift operations Humble reported as non-retryable during this page
+ * session. This state intentionally lives only in memory so reloading the page
+ * always permits another attempt.
  */
-const permanentlyFailed = new Set<string>()
+const nonRetryableClaims = new Set<string>()
 
-const permanentFailureKey = (product: ClaimProduct): string =>
-  `${product.category_human_name}\u0000${product.human_name}\u0000${product.key_type}`
+const nonRetryableClaimKey = (product: ClaimProduct, gift: boolean): string =>
+  JSON.stringify([
+    product.category_id,
+    product.machine_name,
+    product.keyindex ?? null,
+    gift ? 'gift' : 'key',
+  ])
 
-export const markPermanentlyFailed = (product: ClaimProduct): void => {
-  permanentlyFailed.add(permanentFailureKey(product))
+export const markNonRetryableClaim = (product: ClaimProduct, gift: boolean): void => {
+  nonRetryableClaims.add(nonRetryableClaimKey(product, gift))
 }
 
-export const hasPermanentlyFailed = (product: ClaimProduct): boolean =>
-  permanentlyFailed.has(permanentFailureKey(product))
+export const hasNonRetryableClaim = (product: ClaimProduct, gift: boolean): boolean =>
+  nonRetryableClaims.has(nonRetryableClaimKey(product, gift))
+
+export const countNonRetryableFailures = <T extends ClaimProduct>(
+  failures: readonly ClaimFailure<T>[]
+): number => failures.reduce((count, failure) => count + Number(failure.nonRetryable), 0)
 
 export const getErrorMessage = (error: unknown): string =>
   error instanceof Error
@@ -86,7 +103,10 @@ export const getClaimTypeLabel = (product: ClaimProduct): string => {
   return type.charAt(0).toUpperCase() + type.slice(1)
 }
 
-export const createClaimPlan = <T extends ClaimProduct>(products: T[]): ClaimPlan<T> => {
+export const createClaimPlan = <T extends ClaimProduct>(
+  products: T[],
+  skippedCount = 0
+): ClaimPlan<T> => {
   const counts = new Map<string, number>()
   const bundles = new Set<string>()
   let keylessCount = 0
@@ -108,6 +128,7 @@ export const createClaimPlan = <T extends ClaimProduct>(products: T[]): ClaimPla
     keylessCount,
     expiredCount,
     bundleCount: bundles.size,
+    skippedCount,
   }
 }
 
@@ -115,58 +136,92 @@ export const groupClaimResults = <T extends ClaimProduct>(
   report: ClaimReport<T>
 ): ClaimResultGroup<T>[] => {
   const groups = new Map<string, ClaimResultGroup<T>>()
-  const results: Array<ClaimSuccess<T> | ClaimFailure<T>> = [
-    ...report.successes,
-    ...report.failures,
-  ].sort((left, right) => left.index - right.index)
+  const results = [
+    ...report.successes.map((result) => ({ kind: 'success' as const, result })),
+    ...report.failures.map((result) => ({ kind: 'failure' as const, result })),
+    ...report.skipped.map((result) => ({ kind: 'skipped' as const, result })),
+  ].sort((left, right) => left.result.index - right.result.index)
 
-  for (const result of results) {
+  for (const { kind, result } of results) {
     const bundleName = result.product.category_human_name || 'Unknown bundle'
     let group = groups.get(bundleName)
 
     if (!group) {
-      group = { bundleName, successes: [], failures: [] }
+      group = { bundleName, successes: [], failures: [], skipped: [] }
       groups.set(bundleName, group)
     }
 
-    if ('error' in result) {
-      group.failures.push(result)
-    } else {
-      group.successes.push(result)
-    }
+    if (kind === 'success') group.successes.push(result)
+    else if (kind === 'failure') group.failures.push(result)
+    else group.skipped.push(result)
   }
 
   return Array.from(groups.values())
 }
 
 export const formatClaimLog = <T extends ClaimProduct>(report: ClaimReport<T>): string => {
-  const requested = report.successes.length + report.failures.length
+  const attempted = report.successes.length + report.failures.length
+  const nonRetryableCount = countNonRetryableFailures(report.failures)
   const action = report.gift ? 'Gift-link creation' : 'Key reveal'
   const lines = [
     `${action} results`,
-    `Requested: ${requested}`,
+    `Attempted: ${attempted}`,
     `Succeeded: ${report.successes.length}`,
     `Failed: ${report.failures.length}`,
+    ...(nonRetryableCount ? [`  Non-retryable: ${nonRetryableCount}`] : []),
+    ...(report.skipped.length ? [`Skipped: ${report.skipped.length}`] : []),
     report.exportDestination === 'clipboard'
       ? `Export copied to clipboard: ${report.exportSucceeded ? 'Yes' : 'No'}`
       : `Export download started: ${report.exportSucceeded ? 'Yes' : 'No'}`,
     ...(report.exportFilename ? [`Export filename: ${report.exportFilename}`] : []),
     `Keyless/direct-redemption items: ${report.keylessCount}`,
-    '',
-    'Type breakdown:',
-    ...report.typeCounts.map(({ label, count }) => `- ${label}: ${count}`),
+    ...(report.typeCounts.length
+      ? [
+          '',
+          'Type breakdown:',
+          ...report.typeCounts.map(({ label, count }) => `- ${label}: ${count}`),
+        ]
+      : []),
   ]
+
+  if (nonRetryableCount || report.skipped.length) {
+    lines.push(
+      '',
+      'Items marked non-retryable are skipped for the rest of this page session. Refresh the page to try them again.'
+    )
+  }
 
   for (const group of groupClaimResults(report)) {
     lines.push('', `Bundle: ${group.bundleName}`)
+    const groupNonRetryableCount = countNonRetryableFailures(group.failures)
+    const groupSummary = [
+      `${group.successes.length} succeeded`,
+      ...(group.failures.length
+        ? [
+            `${group.failures.length} failed${
+              groupNonRetryableCount ? ` (${groupNonRetryableCount} non-retryable)` : ''
+            }`,
+          ]
+        : []),
+      ...(group.skipped.length ? [`${group.skipped.length} skipped`] : []),
+    ]
+    lines.push(`  Results: ${groupSummary.join(', ')}`)
 
     for (const { product } of group.successes) {
       lines.push(`  SUCCESS - ${product.human_name} [${getClaimTypeLabel(product)}]`)
     }
 
-    for (const { product, error } of group.failures) {
+    for (const { product, error, nonRetryable } of group.failures) {
       const type = getClaimTypeLabel(product)
-      lines.push(`  FAILED - ${product.human_name} [${type}]: ${getErrorMessage(error)}`)
+      const status = nonRetryable ? 'NON-RETRYABLE' : 'FAILED'
+      lines.push(`  ${status} - ${product.human_name} [${type}]: ${getErrorMessage(error)}`)
+    }
+
+    for (const { product } of group.skipped) {
+      const type = getClaimTypeLabel(product)
+      lines.push(
+        `  SKIPPED - ${product.human_name} [${type}]: Previously marked non-retryable this session. Refresh the page to try again.`
+      )
     }
   }
 

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -2,11 +2,12 @@ import { createSignal, onCleanup, Show, type Accessor } from 'solid-js'
 import type { Api } from 'datatables.net-dt'
 import {
   createClaimPlan,
-  hasPermanentlyFailed,
-  markPermanentlyFailed,
+  hasNonRetryableClaim,
+  markNonRetryableClaim,
   type ClaimFailure,
   type ClaimPlan,
   type ClaimReport,
+  type ClaimSkipped,
   type ClaimSuccess,
   type ExportDestination,
 } from '../claim-report'
@@ -53,7 +54,7 @@ type PendingConfirmation = {
 }
 
 const claimProducts = async (
-  products: Product[],
+  claims: ClaimSuccess<Product>[],
   gift: boolean,
   onProgress?: (completed: number) => void
 ): Promise<{
@@ -64,7 +65,7 @@ const claimProducts = async (
   const failures: ClaimFailure<Product>[] = []
   let completed = 0
 
-  await forEachConcurrent(products, CLAIM_CONCURRENCY, async (product, index) => {
+  await forEachConcurrent(claims, CLAIM_CONCURRENCY, async ({ index, product }) => {
     try {
       product.redeemed_key_val = await redeem(product, gift)
       product.type = gift ? 'Gift' : 'Key'
@@ -72,8 +73,9 @@ const claimProducts = async (
       successes.push({ index, product })
     } catch (error) {
       console.error('Error redeeming product:', product.machine_name, error)
-      if (error instanceof RedeemError && error.permanent) markPermanentlyFailed(product)
-      failures.push({ index, product, error })
+      const nonRetryable = error instanceof RedeemError && error.nonRetryable
+      if (nonRetryable) markNonRetryableClaim(product, gift)
+      failures.push({ index, product, error, nonRetryable })
     } finally {
       onProgress?.(++completed)
     }
@@ -291,34 +293,48 @@ export function Actions({
     try {
       const initialSelection = table.rows({ search: 'applied' }).data().toArray() as Product[]
       const claimAsGift = claimType() === 'gift'
-      const claimable = claim()
-        ? initialSelection.filter(
-            (product) =>
-              !hasRedeemedKeyValue(product.redeemed_key_val) && !hasPermanentlyFailed(product)
-          )
+      const claimCandidates = claim()
+        ? initialSelection.filter((product) => !hasRedeemedKeyValue(product.redeemed_key_val))
         : []
+      const initiallyClaimable = claimCandidates.filter(
+        (product) => !hasNonRetryableClaim(product, claimAsGift)
+      )
+      const initiallySkippedCount = claimCandidates.length - initiallyClaimable.length
       let toExport = initialSelection
       let report: ClaimReport<Product> | null = null
 
-      if (claimable.length) {
+      if (claimCandidates.length) {
         const initialProducts = products()
         if (!initialProducts) throw new Error('Product data is unavailable. Please try again.')
 
         const selectionReferences = captureProductReferences(initialProducts, initialSelection)
-        const claimableReferences = captureProductReferences(initialProducts, claimable)
-        const plan = createClaimPlan(claimable)
-        const confirmed = await confirmBulkReveal(plan, claimAsGift, destination)
-        if (!confirmed) return
+        const candidateReferences = captureProductReferences(initialProducts, claimCandidates)
+        const plan = createClaimPlan(initiallyClaimable, initiallySkippedCount)
+
+        if (plan.products.length) {
+          const confirmed = await confirmBulkReveal(plan, claimAsGift, destination)
+          if (!confirmed) return
+        }
 
         // A Steam notice can schedule a product refresh while the confirmation is open. Resolve the
-        // exact confirmed rows against the newest product objects before revealing anything.
+        // exact selected rows against the newest product objects before revealing anything.
         await waitForProductRefresh()
         const latestBeforeClaim = products()
         if (!latestBeforeClaim) throw new Error('Product data is unavailable. Please try again.')
 
-        const currentClaimable = resolveProductReferences(claimableReferences, latestBeforeClaim)
+        const currentCandidates = resolveProductReferences(candidateReferences, latestBeforeClaim)
+        const currentClaims: ClaimSuccess<Product>[] = []
+        const skippedBeforeClaim: ClaimSkipped<Product>[] = []
+
+        currentCandidates.forEach((product, index) => {
+          const result = { index, product }
+          if (hasNonRetryableClaim(product, claimAsGift)) skippedBeforeClaim.push(result)
+          else currentClaims.push(result)
+        })
+
+        const actualPlan = createClaimPlan(currentClaims.map(({ product }) => product))
         const { successes, failures } = await claimProducts(
-          currentClaimable,
+          currentClaims,
           claimAsGift,
           setBulkRevealProgress
         )
@@ -331,19 +347,25 @@ export function Actions({
         if (!latestAfterClaim) throw new Error('Product data is unavailable. Please try again.')
 
         toExport = resolveProductReferences(selectionReferences, latestAfterClaim)
-        const latestClaimable = resolveProductReferences(claimableReferences, latestAfterClaim)
+        const latestCandidates = resolveProductReferences(candidateReferences, latestAfterClaim)
         const updated = new Set<Product>()
 
         const currentSuccesses: ClaimSuccess<Product>[] = successes.map(({ index, product }) => {
-          const latestProduct = latestClaimable[index]
+          const latestProduct = latestCandidates[index]
           applyRedeemedProductState(latestProduct, product)
           updated.add(latestProduct)
           return { index, product: latestProduct }
         })
-        const currentFailures: ClaimFailure<Product>[] = failures.map(({ index, error }) => ({
+        const currentFailures: ClaimFailure<Product>[] = failures.map(
+          ({ index, error, nonRetryable }) => {
+            const product = latestCandidates[index]
+            if (nonRetryable) updated.add(product)
+            return { index, product, error, nonRetryable }
+          }
+        )
+        const currentSkipped: ClaimSkipped<Product>[] = skippedBeforeClaim.map(({ index }) => ({
           index,
-          product: latestClaimable[index],
-          error,
+          product: latestCandidates[index],
         }))
 
         const currentTable = dt()
@@ -358,8 +380,9 @@ export function Actions({
           gift: claimAsGift,
           successes: currentSuccesses,
           failures: currentFailures,
-          typeCounts: plan.typeCounts,
-          keylessCount: plan.keylessCount,
+          skipped: currentSkipped,
+          typeCounts: actualPlan.typeCounts,
+          keylessCount: actualPlan.keylessCount,
           exportDestination: destination,
           exportSucceeded: false,
           exportEmpty: false,

--- a/src/components/BulkRevealDialogs.tsx
+++ b/src/components/BulkRevealDialogs.tsx
@@ -1,5 +1,6 @@
 import { For, Show, type Accessor } from 'solid-js'
 import {
+  countNonRetryableFailures,
   formatClaimLog,
   getClaimTypeLabel,
   getErrorMessage,
@@ -323,6 +324,17 @@ export function BulkRevealConfirmation({
             </div>
           </Show>
 
+          <Show when={plan.skippedCount > 0}>
+            <div class={styles.modal_warning} role="status">
+              <strong>Previously non-retryable</strong>
+              <p>
+                {plan.skippedCount} {pluralize(plan.skippedCount, 'selected item')} will be skipped
+                because Humble previously indicated the operation should not be retried. This lasts
+                only for the current page session; refresh the page to allow another attempt.
+              </p>
+            </div>
+          </Show>
+
           <p class={styles.modal_note} aria-live="polite">
             {processing()
               ? 'Keep this window open while the reveal and export complete.'
@@ -371,7 +383,9 @@ export function BulkRevealResults({
   onClose: () => void
 }) {
   const groups = groupClaimResults(report)
-  const requested = report.successes.length + report.failures.length
+  const attempted = report.successes.length + report.failures.length
+  const nonRetryableCount = countNonRetryableFailures(report.failures)
+  const hasSessionSkips = nonRetryableCount > 0 || report.skipped.length > 0
   const log = formatClaimLog(report)
   let resultGroupsRef!: HTMLDivElement
   let dialogRef: HTMLElement | undefined
@@ -440,19 +454,52 @@ export function BulkRevealResults({
 
         <div class={styles.modal_body} data-modal-scroll-body>
           <div class={styles.result_summary} aria-live="polite">
-            <div class={styles.result_summary_item}>
-              <strong>{requested}</strong>
+            <div
+              class={styles.result_summary_item}
+              title="Reveal or gift-link operations attempted in this run."
+            >
+              <strong>{attempted}</strong>
               <span>Attempted</span>
             </div>
-            <div class={`${styles.result_summary_item} ${styles.result_success_summary}`}>
+            <div
+              class={`${styles.result_summary_item} ${styles.result_success_summary}`}
+              title="Reveal or gift-link operations that succeeded in this run."
+            >
               <strong>{report.successes.length}</strong>
               <span>Succeeded</span>
             </div>
-            <div class={`${styles.result_summary_item} ${styles.result_failure_summary}`}>
+            <div
+              class={`${styles.result_summary_item} ${styles.result_failure_summary}`}
+              title="Reveal or gift-link operations that returned an error, including non-retryable failures."
+            >
               <strong>{report.failures.length}</strong>
               <span>Failed</span>
+              <Show when={nonRetryableCount > 0}>
+                <span
+                  class={styles.result_summary_subcount}
+                  title="Included in Failed. Humble indicated these attempts should not be retried."
+                >
+                  {nonRetryableCount} non-retryable
+                </span>
+              </Show>
             </div>
+            <Show when={report.skipped.length > 0}>
+              <div
+                class={`${styles.result_summary_item} ${styles.result_skipped_summary}`}
+                title="Items not retried because the operation was already marked non-retryable this session. Refresh the page to try again."
+              >
+                <strong>{report.skipped.length}</strong>
+                <span>Skipped</span>
+              </div>
+            </Show>
           </div>
+
+          <Show when={hasSessionSkips}>
+            <p class={styles.result_session_note}>
+              Items marked non-retryable are skipped for the rest of this page session. Refresh the
+              page to allow another attempt.
+            </p>
+          </Show>
 
           <div
             class={`${styles.export_status} ${
@@ -508,17 +555,41 @@ export function BulkRevealResults({
               {(group) => (
                 <details
                   class={styles.result_bundle}
-                  open={groups.length === 1 || group.failures.length > 0}
+                  open={
+                    groups.length === 1 || group.failures.length > 0 || group.skipped.length > 0
+                  }
                 >
                   <summary>
                     <span>{group.bundleName}</span>
                     <span class={styles.result_bundle_counts}>
-                      <span class={styles.result_count_success}>
+                      <span
+                        class={styles.result_count_success}
+                        title="Reveal or gift-link operations that succeeded in this bundle during this run."
+                      >
                         {group.successes.length} succeeded
                       </span>
                       <Show when={group.failures.length > 0}>
-                        <span class={styles.result_count_failure}>
+                        <span
+                          class={styles.result_count_failure}
+                          title="Reveal or gift-link operations in this bundle that returned an error, including non-retryable failures."
+                        >
                           {group.failures.length} failed
+                          <Show when={countNonRetryableFailures(group.failures) > 0}>
+                            <span
+                              class={styles.result_count_detail}
+                              title="Included in Failed. Humble indicated these attempts should not be retried."
+                            >
+                              ({countNonRetryableFailures(group.failures)} non-retryable)
+                            </span>
+                          </Show>
+                        </span>
+                      </Show>
+                      <Show when={group.skipped.length > 0}>
+                        <span
+                          class={styles.result_count_skipped}
+                          title="Items not retried because the operation was already marked non-retryable this session. Refresh the page to try again."
+                        >
+                          {group.skipped.length} skipped
                         </span>
                       </Show>
                     </span>
@@ -550,7 +621,7 @@ export function BulkRevealResults({
                       <h4>Failed</h4>
                       <ul class={styles.result_list}>
                         <For each={group.failures}>
-                          {({ product, error }) => (
+                          {({ product, error, nonRetryable }) => (
                             <li class={styles.result_failure}>
                               <span class={styles.result_icon} aria-hidden="true">
                                 ×
@@ -558,7 +629,34 @@ export function BulkRevealResults({
                               <span>
                                 <strong>{product.human_name}</strong>
                                 <small>
+                                  <Show when={nonRetryable}>
+                                    <span class={styles.result_status_failure}>NON-RETRYABLE</span>{' '}
+                                    —{' '}
+                                  </Show>
                                   <ClaimType product={product} /> — {getErrorMessage(error)}
+                                </small>
+                              </span>
+                            </li>
+                          )}
+                        </For>
+                      </ul>
+                    </Show>
+
+                    <Show when={group.skipped.length > 0}>
+                      <h4>Skipped</h4>
+                      <ul class={styles.result_list}>
+                        <For each={group.skipped}>
+                          {({ product }) => (
+                            <li class={styles.result_skipped}>
+                              <span class={styles.result_icon} aria-hidden="true">
+                                !
+                              </span>
+                              <span>
+                                <strong>{product.human_name}</strong>
+                                <small>
+                                  <span class={styles.result_status_skipped}>SKIPPED</span> —{' '}
+                                  <ClaimType product={product} /> — Previously marked non-retryable
+                                  this session. Refresh the page to try again.
                                 </small>
                               </span>
                             </li>

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,5 +1,5 @@
 import { onCleanup, onMount, type Accessor, type Setter } from 'solid-js'
-import { isKeylessProduct } from '../claim-report'
+import { hasNonRetryableClaim, isKeylessProduct, markNonRetryableClaim } from '../claim-report'
 import { hasRedeemedKeyValue, serializeRedeemedKeyValue } from '../redeemed-key'
 import { captureProductReference, resolveProductReference } from '../product-reference'
 import {
@@ -15,6 +15,7 @@ import {
   clearSteamSupportNotice,
   copyToClipboard,
   redeem,
+  RedeemError,
   fetchRedeemedDate,
   setRedeemedDate,
   showErrorToast,
@@ -622,6 +623,7 @@ export function Table({
     const revealProduct = async (row: Product, gift: boolean): Promise<void> => {
       const keyless = isKeylessProduct(row)
       let keylessConfirmed = false
+      let currentProduct: Product | undefined
 
       try {
         const reference = captureProductReference(products, row)
@@ -637,8 +639,16 @@ export function Table({
         const beforeRedeem = latestProducts()
         if (!beforeRedeem) throw new Error('Product data is unavailable. Please try again.')
 
-        const currentProduct = resolveProductReference(reference, beforeRedeem)
+        currentProduct = resolveProductReference(reference, beforeRedeem)
         if (hasRedeemedKeyValue(currentProduct.redeemed_key_val) || currentProduct.is_gift) return
+
+        if (hasNonRetryableClaim(currentProduct, gift)) {
+          showFlashToast(
+            'Retry for this operation is disabled until the page is refreshed.',
+            'warning'
+          )
+          return
+        }
 
         const value = await redeem(currentProduct, gift)
 
@@ -668,7 +678,21 @@ export function Table({
           )
         }
       } catch (error) {
-        showErrorToast(error)
+        if (currentProduct && error instanceof RedeemError && error.nonRetryable) {
+          markNonRetryableClaim(currentProduct, gift)
+          currentDt()
+            ?.rows((_index, product) => product === currentProduct)
+            .invalidate('data')
+            .draw(false)
+
+          const message = error.message || 'Failed to reveal key'
+          showFlashToast(
+            `${message} Humble marked this attempt non-retryable. Retry for this operation is disabled until the page is refreshed.`,
+            'error'
+          )
+        } else {
+          showErrorToast(error)
+        }
       } finally {
         if (keylessConfirmed) finishKeylessRedemption()
       }
@@ -1004,6 +1028,8 @@ export function Table({
                 }
 
                 if (!hasRedeemedKeyValue(row.redeemed_key_val) && !row.is_gift) {
+                  const revealNonRetryable = hasNonRetryableClaim(row, false)
+                  const giftNonRetryable = hasNonRetryableClaim(row, true)
                   const revealTitle = keyless
                     ? row.is_expired
                       ? 'Attempt direct redemption to the linked account (marked expired); no transferable key will be shown'
@@ -1018,6 +1044,8 @@ export function Table({
                     : row.is_expired
                       ? 'Attempt gift-link creation (marked expired)'
                       : 'Create gift link'
+                  const nonRetryableTitle =
+                    'Non-retryable this session; refresh the page to try again'
 
                   actions.push(
                     hm(
@@ -1025,11 +1053,14 @@ export function Table({
                       {
                         class: styles.btn,
                         type: 'button',
+                        disabled: revealNonRetryable,
+                        title: revealNonRetryable ? nonRetryableTitle : revealTitle,
+                        'aria-label': revealNonRetryable ? nonRetryableTitle : revealTitle,
                         onclick: () => void revealProduct(row, false),
                       },
                       hm('i', {
                         class: keyless ? 'hb hb-link' : 'hb hb-magic',
-                        title: revealTitle,
+                        'aria-hidden': 'true',
                       })
                     ),
                     hm(
@@ -1037,11 +1068,14 @@ export function Table({
                       {
                         class: styles.btn,
                         type: 'button',
+                        disabled: giftNonRetryable,
+                        title: giftNonRetryable ? nonRetryableTitle : giftTitle,
+                        'aria-label': giftNonRetryable ? nonRetryableTitle : giftTitle,
                         onclick: () => void revealProduct(row, true),
                       },
                       hm('i', {
                         class: 'hb hb-gift',
-                        title: giftTitle,
+                        'aria-hidden': 'true',
                       })
                     )
                   )

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -473,9 +473,16 @@ tr.expired {
 .modal_stats,
 .result_summary {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 10px;
   margin-bottom: 18px;
+}
+
+.modal_stats {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.result_summary {
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
 }
 
 .modal_stat,
@@ -648,6 +655,31 @@ tr.expired {
   color: #9c2636;
 }
 
+.result_summary_item .result_summary_subcount {
+  padding-left: 10px;
+  margin-top: 6px;
+  color: #9c2636;
+  font-size: 11px;
+  font-weight: 700;
+  text-align: left;
+}
+
+.result_skipped_summary {
+  background: #fff3cd;
+  border-color: #e9cf78;
+}
+
+.result_skipped_summary strong {
+  color: #664d03;
+}
+
+.result_session_note {
+  margin: -7px 0 16px;
+  color: #626a75;
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+
 .export_status {
   padding: 10px 12px;
   margin-bottom: 16px;
@@ -734,7 +766,8 @@ tr.expired {
 }
 
 .result_count_success,
-.result_count_failure {
+.result_count_failure,
+.result_count_skipped {
   padding: 2px 7px;
   border-radius: 999px;
 }
@@ -747,6 +780,15 @@ tr.expired {
 .result_count_failure {
   background: #f5d9dd;
   color: #9c2636;
+}
+
+.result_count_detail {
+  margin-left: 3px;
+}
+
+.result_count_skipped {
+  background: #fff3cd;
+  color: #664d03;
 }
 
 .result_bundle_body {
@@ -801,6 +843,25 @@ tr.expired {
   background: #fcf0f2;
 }
 
+.result_skipped {
+  background: #fff8df;
+}
+
+.result_status_failure,
+.result_status_skipped {
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.result_status_failure {
+  color: #9c2636;
+}
+
+.result_status_skipped {
+  color: #664d03;
+}
+
 .result_icon {
   flex: 0 0 auto;
   width: 18px;
@@ -816,6 +877,10 @@ tr.expired {
 
 .result_failure .result_icon {
   color: #b52f42;
+}
+
+.result_skipped .result_icon {
+  color: #8a6500;
 }
 
 @media (max-width: 600px) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -356,19 +356,14 @@ type RedeemResponse = {
   key?: unknown
 }
 
-/**
- * A failed reveal. `permanent` is true when Humble explicitly reported the
- * failure as non-retryable (`redeem_retryable: false`), which is how expired
- * keys are signalled. Retrying those always fails the same way, so callers can
- * use this to skip them instead of re-requesting on every bulk reveal.
- */
+/** A failed reveal response, including Humble's explicit retry signal when present. */
 export class RedeemError extends Error {
-  readonly permanent: boolean
+  readonly nonRetryable: boolean
 
-  constructor(message: string, permanent: boolean) {
+  constructor(message: string, nonRetryable: boolean) {
     super(message)
     this.name = 'RedeemError'
-    this.permanent = permanent
+    this.nonRetryable = nonRetryable
   }
 }
 


### PR DESCRIPTION
## Summary

This follow-up to #55 makes non-retryable reveal failures safer and clearer.

Keys are still always attempted at least once. If Humble returns `redeem_retryable: false`, that operation is marked non-retryable for the current page session and later attempts are skipped until the page is refreshed.

## Changes

- Track non-retryable state by the actual entitlement and operation instead of display names.
- Keep reveal and gift-link retry state independent.
- Rename internal `permanent` terminology to `nonRetryable`.
- Show first non-retryable failures explicitly as `NON-RETRYABLE`.
- Show later bulk attempts as `SKIPPED` instead of silently omitting them.
- Keep non-retryable failures included under `Failed`, with the subtype shown in overall and bundle summaries.
- Add clear tooltips and session-reset guidance.
- Disable affected individual reveal/gift actions for the current session with refresh-to-retry guidance.
- Include non-retryable and skipped results in copyable/downloadable bulk reveal logs.
- Keep all retry-suppression state memory-only so refreshing the page always allows another attempt.